### PR TITLE
Fix issues with CPU-only operation of SPECTER+MFR affinity model

### DIFF
--- a/expertise/models/multifacet_recommender/mfr_src/model.py
+++ b/expertise/models/multifacet_recommender/mfr_src/model.py
@@ -235,7 +235,7 @@ class EMB2SEQ(nn.Module):
         def prepare_posi_emb(input, poistion_emb, drop):
             batch_size = input.size(1)
             n_basis = input.size(0)
-            input_pos = torch.arange(n_basis,dtype=torch.long,device = input.get_device()).expand(batch_size,n_basis).permute(1,0)
+            input_pos = torch.arange(n_basis,dtype=torch.long,device = input.device).expand(batch_size,n_basis).permute(1,0)
             poistion_emb_input = poistion_emb(input_pos)
             poistion_emb_input = drop(poistion_emb_input)
             return poistion_emb_input
@@ -251,7 +251,7 @@ class EMB2SEQ(nn.Module):
             emb = self.drop(emb_raw)
         elif self.positional_option == 'cat':
             #batch_size = input.size(1)
-            #input_pos = torch.arange(self.n_basis,dtype=torch.long,device = input.get_device()).expand(batch_size,self.n_basis).permute(1,0)
+            #input_pos = torch.arange(self.n_basis,dtype=torch.long,device = input.device).expand(batch_size,self.n_basis).permute(1,0)
 
             #poistion_emb_input = self.poistion_emb(input_pos)
             #poistion_emb_input = self.drop(poistion_emb_input)
@@ -452,7 +452,7 @@ class SEQ2EMB(nn.Module):
             #self.encoder = nn.Embedding.from_pretrained(external_emb.clone(), freeze = False)
             if len(init_idx) > 0:
                 print("Randomly initializes embedding for ", len(init_idx), " words")
-                device = self.encoder.weight.data.get_device()
+                device = self.encoder.weight.data.device
                 extra_init_emb = torch.randn(len(init_idx), ninp, requires_grad = False, device = device)
                 #extra_init_emb = extra_init_emb / (0.000000000001 + extra_init_emb.norm(dim = 1, keepdim=True))
                 self.encoder.weight.data[init_idx, :] = extra_init_emb

--- a/expertise/models/multifacet_recommender/multifacet_recommender.py
+++ b/expertise/models/multifacet_recommender/multifacet_recommender.py
@@ -136,7 +136,7 @@ def load_ext_emb(emb_file, target_emb_sz, idx2word_freq, num_special_token, devi
     num_w = len(idx2word_freq)
     if len(emb_file) > 0:
         if emb_file[-3:] == '.pt':
-            target_emb = torch.load(emb_file).to(device=device)
+            target_emb = torch.load(emb_file, map_location=device)
             target_emb.requires_grad = False
             target_emb_sz = target_emb.size(1)
         else:
@@ -738,13 +738,17 @@ class MultiFacetRecommender(object):
             sys.exit(1)
 
         if self.continue_train:
-            encoder.load_state_dict(torch.load(os.path.join(self.model_checkpoint_dir, 'encoder.pt')))
-            decoder.load_state_dict(torch.load(os.path.join(self.model_checkpoint_dir, 'decoder.pt')))
+            encoder.load_state_dict(torch.load(os.path.join(self.model_checkpoint_dir, 'encoder.pt'),
+                                               map_location=self.device))
+            decoder.load_state_dict(torch.load(os.path.join(self.model_checkpoint_dir, 'decoder.pt'),
+                                               map_location=self.device))
             if self.loading_target_embedding:
-                user_emb_load = torch.load(os.path.join(self.model_checkpoint_dir, 'user_emb.pt'))
+                user_emb_load = torch.load(os.path.join(self.model_checkpoint_dir, 'user_emb.pt'),
+                                           map_location=self.device)
                 user_emb = user_emb.new_tensor(user_emb_load)
                 if self.tag_w > 0:
-                    tag_emb_load = torch.load(os.path.join(self.model_checkpoint_dir, 'tag_emb.pt'))
+                    tag_emb_load = torch.load(os.path.join(self.model_checkpoint_dir, 'tag_emb.pt'),
+                                              map_location=self.device)
                     tag_emb = tag_emb.new_tensor(tag_emb_load)
 
         parallel_encoder, parallel_decoder = output_parallel_models(self.use_cuda, self.single_gpu, encoder, decoder)


### PR DESCRIPTION
Closes #56 

- Changing `tensor.get_device()` to `tensor.device` fixes the issue
- When loading tensors, `map_location` must be appropriately set