### PR TITLE
Check valid members against the set of all confirmed emails

### DIFF
--- a/tests/test_create_dataset.py
+++ b/tests/test_create_dataset.py
@@ -22,6 +22,7 @@ def mock_client():
         for profile in profiles:
             profile = openreview.Profile.from_json(profile)
             if profile.content.get('emails') and len(profile.content.get('emails')):
+                profile.content['emailsConfirmed'] = profile.content.get('emails')
                 profiles_dict_emails[profile.content['emails'][0]] = profile
             profiles_dict_tilde[profile.id] = profile
         if confirmedEmails:


### PR DESCRIPTION
There was an issue in the `create_dataset` when two (or more) confirmed emails belonged to the same person. Previously it would find the Profile correctly but would only associate the Profile to a single email address, the other(s) would be marked as not having a Profile, which was wrong. This PR fixes the issue.