### PR TITLE
Fix API functionality

### DIFF
--- a/expertise/service/README.md
+++ b/expertise/service/README.md
@@ -22,9 +22,26 @@ Returns code `200` on successful job submission with: `{"job_id": "string"}`\
 Returns code `400` if there was an error in the submitted config
 
 ## `GET /expertise/status`
-This endpoint gets the status of all jobs submitted by the user, or a single job with the given `job_id`. A valid request body has the following format:
+This endpoint gets the status of a single job with the given `job_id`. A valid request body has the following format:
 ```
-{"id": "string" [Optional]}
+{"id": "string"}
+```
+
+Returns the status, if any, that were submitted by the user and has the job id:
+```
+{
+	"job_id": "string",
+	"name": "string",
+	"status": "string",
+	"description": "string",
+	"config": {...}
+}
+```
+
+## `GET /expertise/status/all`
+This endpoint gets the status of all jobs submitted by the user. A valid request body has the following format:
+```
+{}
 ```
 
 Returns a list of jobs, if any, that were submitted by the user and has the job id if provided:
@@ -35,7 +52,8 @@ Returns a list of jobs, if any, that were submitted by the user and has the job 
         "job_id": "string",
         "name": "string",
         "status": "string",
-        "description": "string"
+        "description": "string",
+        "config": {...}
       }
   ]
 }

--- a/expertise/service/celery_tasks.py
+++ b/expertise/service/celery_tasks.py
@@ -25,7 +25,7 @@ def update_status(job_dir, new_status, desc=None):
         config['description'] = descriptions[new_status]
     else:
         config['description'] = desc
-    config['mdate'] = int(time.time())
+    config['mdate'] = int(time.time() * 1000)
     with open(os.path.join(config['job_dir'], 'config.json'), 'w+') as f:
         json.dump(config, f, ensure_ascii=False, indent=4)
 

--- a/expertise/service/celery_tasks.py
+++ b/expertise/service/celery_tasks.py
@@ -1,5 +1,5 @@
 from functools import update_wrapper
-import logging, json, os, shutil
+import logging, json, os, shutil, time
 from .utils import mock_client
 from expertise.execute_expertise import execute_create_dataset, execute_expertise
 from expertise.service.expertise import JobStatus, JobDescription
@@ -25,6 +25,7 @@ def update_status(job_dir, new_status, desc=None):
         config['description'] = descriptions[new_status]
     else:
         config['description'] = desc
+    config['mdate'] = int(time.time())
     with open(os.path.join(config['job_dir'], 'config.json'), 'w+') as f:
         json.dump(config, f, ensure_ascii=False, indent=4)
 

--- a/expertise/service/config/default.cfg
+++ b/expertise/service/config/default.cfg
@@ -5,3 +5,16 @@ SPECTER_DIR = '../expertise-utils/specter/'
 MFR_VOCAB_DIR = '../expertise-utils/multifacet_recommender/feature_vocab_file'
 MFR_CHECKPOINT_DIR = '../expertise-utils/multifacet_recommender/mfr_model_checkpoint/'
 CELERY_CONFIG = 'expertise.service.config.celery_config'
+DEFAULT_CONFIG = {
+    "dataset": {},
+    "model": "specter+mfr",
+    "model_params": {
+        "use_title": True,
+        "batch_size": 4,
+        "use_abstract": True,
+        "average_score": False,
+        "max_score": True,
+        "skip_specter": False,
+        "use_cuda": False
+    }
+}

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -90,6 +90,7 @@ class ExpertiseService(object):
             config['model_params'][field] = root_dir
         config['job_dir'] = root_dir
         config['cdate'] = int(time.time())
+        config['mdate'] = config['cdate']
         config['status'] = JobStatus.INITIALIZED.value
         config['description'] = descriptions[JobStatus.INITIALIZED]
 
@@ -311,6 +312,7 @@ class ExpertiseService(object):
         config = self._prepare_config(request)
 
         self.logger.info(f'Config: {config}')
+        config['mdate'] = int(time.time())
         config['status'] = JobStatus.QUEUED
         config['description'] = descriptions[JobStatus.QUEUED]
 

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -89,7 +89,7 @@ class ExpertiseService(object):
         for field in self.path_fields:
             config['model_params'][field] = root_dir
         config['job_dir'] = root_dir
-        config['cdate'] = int(time.time())
+        config['cdate'] = int(time.time() * 1000)
         config['mdate'] = config['cdate']
         config['status'] = JobStatus.INITIALIZED.value
         config['description'] = descriptions[JobStatus.INITIALIZED]
@@ -312,7 +312,7 @@ class ExpertiseService(object):
         config = self._prepare_config(request)
 
         self.logger.info(f'Config: {config}')
-        config['mdate'] = int(time.time())
+        config['mdate'] = int(time.time() * 1000)
         config['status'] = JobStatus.QUEUED
         config['description'] = descriptions[JobStatus.QUEUED]
 

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -31,29 +31,12 @@ class JobDescription(dict, Enum):
         JobStatus.COMPLETED: 'Job is complete and the computed scores are ready',
     }
 
-
-def _get_default_config():
-    config = {
-        "dataset": {},
-        "model": "specter+mfr",
-        "model_params": {
-            "use_title": True,
-            "batch_size": 4,
-            "use_abstract": True,
-            "average_score": False,
-            "max_score": True,
-            "skip_specter": False,
-            "use_cuda": False
-        }
-    }
-    return config
-
-
 class ExpertiseService(object):
 
     def __init__(self, client, config, logger):
         self.client = client
         self.logger = logger
+        self.server_config = config
         self.working_dir = config['WORKING_DIR']
         self.specter_dir = config['SPECTER_DIR']
         self.mfr_feature_vocab_file = config['MFR_VOCAB_DIR']
@@ -64,6 +47,9 @@ class ExpertiseService(object):
         self.optional_model_params = ['use_title', 'use_abstract', 'average_score', 'max_score', 'skip_specter']
         self.optional_fields = ['model', 'model_params', 'exclusion_inv', 'token', 'baseurl']
         self.path_fields = ['work_dir', 'scores_path', 'publications_path', 'submissions_path']
+
+    def _get_default_config(self):
+        return self.server_config['DEFAULT_CONFIG']
 
     def _filter_config(self, running_config):
         """
@@ -142,7 +128,7 @@ class ExpertiseService(object):
         :raises Exception: If the request is missing a required field, contains an unexpected field or an
                            unexpected model param
         """
-        config = _get_default_config()
+        config = self._get_default_config()
 
         # Populate fields
         failed_request = False

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -364,6 +364,8 @@ class ExpertiseService(object):
                     'name': config['name'],
                     'status': status,
                     'description': description,
+                    'cdate': config['cdate'],
+                    'mdate': config['mdate'],
                     'config': filtered_config
                 }
             )
@@ -412,6 +414,8 @@ class ExpertiseService(object):
             'name': config['name'],
             'status': status,
             'description': description,
+            'cdate': config['cdate'],
+            'mdate': config['mdate'],
             'config': filtered_config
         }
 

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -389,6 +389,8 @@ class ExpertiseService(object):
         # Assert that there should only be 1 matching job
         if len(job_subdirs) > 1:
             raise OpenReviewException('Single job not found: multiple matching jobs returned')
+        elif len(job_subdirs) == 0:
+            raise OpenReviewException('Job not found')
 
         job_dir = job_subdirs[0]
         search_dir = os.path.join(self.working_dir, job_dir)

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -181,8 +181,8 @@ class ExpertiseService(object):
 
         :returns: A list of subdirectories not prefixed by the given root directory
         """
-        subdirs = [name for name in os.listdir(self.working_dir) if os.path.isdir(os.path.join(self.working_dir, name))]
         if user_id.lower() in SUPERUSER_IDS:
+            subdirs = [name for name in os.listdir(self.working_dir) if os.path.isdir(os.path.join(self.working_dir, name))]
             return subdirs
         else:
             # If given a profile ID, assume looking for job dirs that contain a config with the
@@ -243,9 +243,9 @@ class ExpertiseService(object):
             else:
                 index[user_id].append(job_id)
         
-        # Write out the index
-        with open(os.path.join(self.working_dir, 'index.json'), 'w+') as f:
-            json.dump(index, f, ensure_ascii=False, indent=4)
+            # Write out the index
+            with open(os.path.join(self.working_dir, 'index.json'), 'w+') as f:
+                json.dump(index, f, ensure_ascii=False, indent=4)
     
     def _get_from_user_index(self, user_id):
         """
@@ -299,9 +299,9 @@ class ExpertiseService(object):
             else:
                 raise OpenReviewException('User not found: no jobs submitted with this user ID')
         
-        # Write out the index
-        with open(os.path.join(self.working_dir, 'index.json'), 'w+') as f:
-            json.dump(index, f, ensure_ascii=False, indent=4)
+            # Write out the index
+            with open(os.path.join(self.working_dir, 'index.json'), 'w+') as f:
+                json.dump(index, f, ensure_ascii=False, indent=4)
 
     def start_expertise(self, request):
         descriptions = JobDescription.VALS.value

--- a/expertise/service/routes.py
+++ b/expertise/service/routes.py
@@ -55,7 +55,6 @@ def format_error(status_code, description):
     template = {
         'name': error_name,
         'message': description,
-        'status': status_code
     }
 
     return template

--- a/expertise/service/routes.py
+++ b/expertise/service/routes.py
@@ -165,7 +165,7 @@ def all_jobs():
 
     try:
         # Parse query parameters
-        result = ExpertiseService(openreview_client, flask.current_app.config, flask.current_app.logger).get_expertise_status(user_id, None)
+        result = ExpertiseService(openreview_client, flask.current_app.config, flask.current_app.logger).get_expertise_all_status(user_id)
         flask.current_app.logger.debug('GET returns ' + str(result))
         return flask.jsonify(result), 200
 

--- a/expertise/service/routes.py
+++ b/expertise/service/routes.py
@@ -58,7 +58,7 @@ def expertise():
     user_id = get_user_id(openreview_client)
     if not user_id:
         flask.current_app.logger.error('No Authorization token in headers')
-        return flask.jsonify({ 'error': 'Forbidden: No Authorization token in headers'}), 403
+        return flask.jsonify({'status': 'Error', 'description': 'Forbidden: No Authorization token in headers'}), 403
 
     try:
         flask.current_app.logger.info('Received expertise request')
@@ -90,12 +90,12 @@ def expertise():
         elif 'bad request' in error_type.lower():
             status = 400
 
-        return flask.jsonify({'error': error_type}), status
+        return flask.jsonify({'status': 'Error', 'description': error_type}), status
 
     # pylint:disable=broad-except
     except Exception as error_handle:
         flask.current_app.logger.error(str(error_handle))
-        return flask.jsonify({'error': 'Internal server error: {}'.format(error_handle)}), 500
+        return flask.jsonify({'status': 'Error', 'description': 'Internal server error: {}'.format(error_handle)}), 500
 
 
 @BLUEPRINT.route('/expertise/status', methods=['GET'])
@@ -115,7 +115,7 @@ def jobs():
 
     if not user_id:
         flask.current_app.logger.error('No Authorization token in headers')
-        return flask.jsonify({ 'error': 'Forbidden: No Authorization token in headers'}), 403
+        return flask.jsonify({'status': 'Error', 'description': 'Forbidden: No Authorization token in headers'}), 403
 
     try:
         # Parse query parameters
@@ -139,12 +139,12 @@ def jobs():
         elif 'bad request' in error_type.lower():
             status = 400
 
-        return flask.jsonify({'error': error_type}), status
+        return flask.jsonify({'status': 'Error', 'description': error_type}), status
 
     # pylint:disable=broad-except
     except Exception as error_handle:
         flask.current_app.logger.error(str(error_handle))
-        return flask.jsonify({'error': 'Internal server error: {}'.format(error_handle)}), 500
+        return flask.jsonify({'status': 'Error', 'description': 'Internal server error: {}'.format(error_handle)}), 500
 
 @BLUEPRINT.route('/expertise/status/all', methods=['GET'])
 def all_jobs():
@@ -163,7 +163,7 @@ def all_jobs():
 
     if not user_id:
         flask.current_app.logger.error('No Authorization token in headers')
-        return flask.jsonify({ 'error': 'Forbidden: No Authorization token in headers'}), 403
+        return flask.jsonify({'status': 'Error', 'description': 'Forbidden: No Authorization token in headers'}), 403
 
     try:
         # Parse query parameters
@@ -184,12 +184,12 @@ def all_jobs():
         elif 'bad request' in error_type.lower():
             status = 400
 
-        return flask.jsonify({'error': error_type}), status
+        return flask.jsonify({'status': 'Error', 'description': error_type}), status
 
     # pylint:disable=broad-except
     except Exception as error_handle:
         flask.current_app.logger.error(str(error_handle))
-        return flask.jsonify({'error': 'Internal server error: {}'.format(error_handle)}), 500
+        return flask.jsonify({'status': 'Error', 'description': 'Internal server error: {}'.format(error_handle)}), 500
 
 @BLUEPRINT.route('/expertise/results', methods=['GET'])
 def results():
@@ -212,7 +212,7 @@ def results():
 
     if not user_id:
         flask.current_app.logger.error('No Authorization token in headers')
-        return flask.jsonify({ 'error': 'Forbidden: No Authorization token in headers'}), 403
+        return flask.jsonify({'status': 'Error', 'description': 'Forbidden: No Authorization token in headers'}), 403
 
     try:
         # Parse query parameters
@@ -239,9 +239,9 @@ def results():
         elif 'bad request' in error_type.lower():
             status = 400
 
-        return flask.jsonify({'error': error_type}), status
+        return flask.jsonify({'status': 'Error', 'description': error_type}), status
 
     # pylint:disable=broad-except
     except Exception as error_handle:
         flask.current_app.logger.error(str(error_handle))
-        return flask.jsonify({'error', 'Internal server error: {}'.format(error_handle)}), 500
+        return flask.jsonify({'status': 'Error', 'description': 'Internal server error: {}'.format(error_handle)}), 500

--- a/expertise/service/routes.py
+++ b/expertise/service/routes.py
@@ -136,6 +136,8 @@ def jobs():
             status = 404
         elif 'forbidden' in error_type.lower():
             status = 403
+        elif 'bad request' in error_type.lower():
+            status = 400
 
         return flask.jsonify({'error': error_type}), status
 
@@ -179,6 +181,8 @@ def all_jobs():
             status = 404
         elif 'forbidden' in error_type.lower():
             status = 403
+        elif 'bad request' in error_type.lower():
+            status = 400
 
         return flask.jsonify({'error': error_type}), status
 

--- a/expertise/service/routes.py
+++ b/expertise/service/routes.py
@@ -29,6 +29,37 @@ def get_client():
         baseurl=flask.current_app.config['OPENREVIEW_BASEURL']
     )
 
+def format_error(status_code, description):
+    '''
+    Formulates an error that is in the same format as the OpenReview API errors
+
+    :param status_code: The status code determined by looking at the description
+    :type status_code: int
+
+    :param description: Useful information about the error
+    :type description: str
+
+    :returns template: A dictionary that zips all the information into a proper format
+    '''
+    # Parse status code
+    error_name = ''
+    if status_code == 400:
+        error_name = 'BadRequestError'
+    elif status_code == 403:
+        error_name = 'ForbiddenError'
+    elif status_code == 404:
+        error_name = 'NotFoundError'
+    elif status_code == 500:
+        error_name = 'InternalServerError'
+
+    template = {
+        'name': error_name,
+        'message': description,
+        'status': status_code
+    }
+
+    return template
+
 @BLUEPRINT.route('/expertise/test')
 def test():
     """Test endpoint."""
@@ -58,7 +89,7 @@ def expertise():
     user_id = get_user_id(openreview_client)
     if not user_id:
         flask.current_app.logger.error('No Authorization token in headers')
-        return flask.jsonify({'status': 'Error', 'description': 'Forbidden: No Authorization token in headers'}), 403
+        return flask.jsonify(format_error(403, 'Forbidden: No Authorization token in headers')), 403
 
     try:
         flask.current_app.logger.info('Received expertise request')
@@ -90,12 +121,12 @@ def expertise():
         elif 'bad request' in error_type.lower():
             status = 400
 
-        return flask.jsonify({'status': 'Error', 'description': error_type}), status
+        return flask.jsonify(format_error(status, error_type)), status
 
     # pylint:disable=broad-except
     except Exception as error_handle:
         flask.current_app.logger.error(str(error_handle))
-        return flask.jsonify({'status': 'Error', 'description': 'Internal server error: {}'.format(error_handle)}), 500
+        return flask.jsonify(format_error(500, 'Internal server error: {}'.format(error_handle))), 500
 
 
 @BLUEPRINT.route('/expertise/status', methods=['GET'])
@@ -115,7 +146,7 @@ def jobs():
 
     if not user_id:
         flask.current_app.logger.error('No Authorization token in headers')
-        return flask.jsonify({'status': 'Error', 'description': 'Forbidden: No Authorization token in headers'}), 403
+        return flask.jsonify(format_error(403, 'Forbidden: No Authorization token in headers')), 403
 
     try:
         # Parse query parameters
@@ -139,12 +170,12 @@ def jobs():
         elif 'bad request' in error_type.lower():
             status = 400
 
-        return flask.jsonify({'status': 'Error', 'description': error_type}), status
+        return flask.jsonify(format_error(status, error_type)), status
 
     # pylint:disable=broad-except
     except Exception as error_handle:
         flask.current_app.logger.error(str(error_handle))
-        return flask.jsonify({'status': 'Error', 'description': 'Internal server error: {}'.format(error_handle)}), 500
+        return flask.jsonify(format_error(500, 'Internal server error: {}'.format(error_handle))), 500
 
 @BLUEPRINT.route('/expertise/status/all', methods=['GET'])
 def all_jobs():
@@ -163,7 +194,7 @@ def all_jobs():
 
     if not user_id:
         flask.current_app.logger.error('No Authorization token in headers')
-        return flask.jsonify({'status': 'Error', 'description': 'Forbidden: No Authorization token in headers'}), 403
+        return flask.jsonify(format_error(403, 'Forbidden: No Authorization token in headers')), 403
 
     try:
         # Parse query parameters
@@ -184,12 +215,12 @@ def all_jobs():
         elif 'bad request' in error_type.lower():
             status = 400
 
-        return flask.jsonify({'status': 'Error', 'description': error_type}), status
+        return flask.jsonify(format_error(status, error_type)), status
 
     # pylint:disable=broad-except
     except Exception as error_handle:
         flask.current_app.logger.error(str(error_handle))
-        return flask.jsonify({'status': 'Error', 'description': 'Internal server error: {}'.format(error_handle)}), 500
+        return flask.jsonify(format_error(500, 'Internal server error: {}'.format(error_handle))), 500
 
 @BLUEPRINT.route('/expertise/delete', methods=['GET'])
 def delete_job():
@@ -208,7 +239,7 @@ def delete_job():
 
     if not user_id:
         flask.current_app.logger.error('No Authorization token in headers')
-        return flask.jsonify({'status': 'Error', 'description': 'Forbidden: No Authorization token in headers'}), 403
+        return flask.jsonify(format_error(403, 'Forbidden: No Authorization token in headers')), 403
 
     try:
         # Parse query parameters
@@ -232,12 +263,12 @@ def delete_job():
         elif 'bad request' in error_type.lower():
             status = 400
 
-        return flask.jsonify({'status': 'Error', 'description': error_type}), status
+        return flask.jsonify(format_error(status, error_type)), status
 
     # pylint:disable=broad-except
     except Exception as error_handle:
         flask.current_app.logger.error(str(error_handle))
-        return flask.jsonify({'status': 'Error', 'description': 'Internal server error: {}'.format(error_handle)}), 500
+        return flask.jsonify(format_error(500, 'Internal server error: {}'.format(error_handle))), 500
 
 @BLUEPRINT.route('/expertise/results', methods=['GET'])
 def results():
@@ -260,7 +291,7 @@ def results():
 
     if not user_id:
         flask.current_app.logger.error('No Authorization token in headers')
-        return flask.jsonify({'status': 'Error', 'description': 'Forbidden: No Authorization token in headers'}), 403
+        return flask.jsonify(format_error(403, 'Forbidden: No Authorization token in headers')), 403
 
     try:
         # Parse query parameters
@@ -287,9 +318,9 @@ def results():
         elif 'bad request' in error_type.lower():
             status = 400
 
-        return flask.jsonify({'status': 'Error', 'description': error_type}), status
+        return flask.jsonify(format_error(status, error_type)), status
 
     # pylint:disable=broad-except
     except Exception as error_handle:
         flask.current_app.logger.error(str(error_handle))
-        return flask.jsonify({'status': 'Error', 'description': 'Internal server error: {}'.format(error_handle)}), 500
+        return flask.jsonify(format_error(500, 'Internal server error: {}'.format(error_handle))), 500

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -249,6 +249,7 @@ class TestExpertiseService():
         assert response['status'] == 'Completed'
         assert response['name'] == 'test_run'
         assert response['description'] == 'Job is complete and the computed scores are ready'
+        assert response['cdate'] <= response['mdate']
         
         # Check config fields
         returned_config = response['config']
@@ -338,6 +339,7 @@ class TestExpertiseService():
         assert response['name'] == 'test_run'
         assert response['status'].strip() == 'Error'
         assert response['description'] == 'use_title and use_abstract cannot both be False'
+        assert response['cdate'] <= response['mdate']
         ###assert os.path.isfile(f"{server_config['WORKING_DIR']}/{job_id}/err.log")
 
         # Clean up error job

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -85,9 +85,9 @@ class TestExpertiseService():
             content_type='application/json'
         )
         assert response.status_code == 400, f'{response.json}'
-        assert response.json['status'] == 'Error'
-        assert 'bad request' in response.json['description'].lower()
-        assert response.json['description'] == 'Bad request: missing required field: name match_group paper_invitation'
+        assert 'Error' in response.json['name']
+        assert 'bad request' in response.json['message'].lower()
+        assert response.json['message'] == 'Bad request: missing required field: name match_group paper_invitation'
 
     def test_request_expertise_with_missing_required_fields(self, openreview_context, celery_session_app, celery_session_worker):
         # Submitting a partially filled out config without a required field
@@ -109,9 +109,9 @@ class TestExpertiseService():
             content_type='application/json'
         )
         assert response.status_code == 400, f'{response.json}'
-        assert response.json['status'] == 'Error'
-        assert 'bad request' in response.json['description'].lower()
-        assert response.json['description'] == 'Bad request: missing required field: paper_invitation'
+        assert 'Error' in response.json['name']
+        assert 'bad request' in response.json['message'].lower()
+        assert response.json['message'] == 'Bad request: missing required field: paper_invitation'
 
     def test_request_expertise_with_invalid_field(self, openreview_context, celery_session_app, celery_session_worker):
         # Submit a working config with an extra field that is not allowed
@@ -135,9 +135,9 @@ class TestExpertiseService():
             content_type='application/json'
         )
         assert response.status_code == 400, f'{response.json}'
-        assert response.json['status'] == 'Error'
-        assert 'bad request' in response.json['description'].lower()
-        assert response.json['description'] == 'Bad request: unexpected field: unexpected_field'
+        assert 'Error' in response.json['name']
+        assert 'bad request' in response.json['message'].lower()
+        assert response.json['message'] == 'Bad request: unexpected field: unexpected_field'
 
     def test_request_expertise_with_invalid_and_missing_required_field(self, openreview_context, celery_session_app, celery_session_worker):
         # Submit a working config with an extra field that is not allowed
@@ -160,9 +160,9 @@ class TestExpertiseService():
             content_type='application/json'
         )
         assert response.status_code == 400, f'{response.json}'
-        assert response.json['status'] == 'Error'
-        assert 'bad request' in response.json['description'].lower()
-        assert response.json['description'] == 'Bad request: missing required field: name\nunexpected field: unexpected_field'
+        assert 'Error' in response.json['name']
+        assert 'bad request' in response.json['message'].lower()
+        assert response.json['message'] == 'Bad request: missing required field: name\nunexpected field: unexpected_field'
 
     def test_request_expertise_with_invalid_model_param(self, openreview_context, celery_session_app, celery_session_worker):
         # Submit a working config with an extra model param field
@@ -186,9 +186,9 @@ class TestExpertiseService():
             content_type='application/json'
         )
         assert response.status_code == 400, f'{response.json}'
-        assert response.json['status'] == 'Error'
-        assert 'bad request' in response.json['description'].lower()
-        assert response.json['description'] == 'Bad request: unexpected model param: dummy_param'
+        assert 'Error' in response.json['name']
+        assert 'bad request' in response.json['message'].lower()
+        assert response.json['message'] == 'Bad request: unexpected model param: dummy_param'
 
     def test_request_expertise_with_valid_parameters(self, openreview_context, celery_session_app, celery_session_worker):
         # Submit a working job and return the job ID

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -85,8 +85,9 @@ class TestExpertiseService():
             content_type='application/json'
         )
         assert response.status_code == 400, f'{response.json}'
-        assert 'bad request' in response.json['error'].lower()
-        assert response.json['error'] == 'Bad request: missing required field: name match_group paper_invitation'
+        assert response.json['status'] == 'Error'
+        assert 'bad request' in response.json['description'].lower()
+        assert response.json['description'] == 'Bad request: missing required field: name match_group paper_invitation'
 
     def test_request_expertise_with_missing_required_fields(self, openreview_context, celery_session_app, celery_session_worker):
         # Submitting a partially filled out config without a required field
@@ -108,8 +109,9 @@ class TestExpertiseService():
             content_type='application/json'
         )
         assert response.status_code == 400, f'{response.json}'
-        assert 'bad request' in response.json['error'].lower()
-        assert response.json['error'] == 'Bad request: missing required field: paper_invitation'
+        assert response.json['status'] == 'Error'
+        assert 'bad request' in response.json['description'].lower()
+        assert response.json['description'] == 'Bad request: missing required field: paper_invitation'
 
     def test_request_expertise_with_invalid_field(self, openreview_context, celery_session_app, celery_session_worker):
         # Submit a working config with an extra field that is not allowed
@@ -133,8 +135,9 @@ class TestExpertiseService():
             content_type='application/json'
         )
         assert response.status_code == 400, f'{response.json}'
-        assert 'bad request' in response.json['error'].lower()
-        assert response.json['error'] == 'Bad request: unexpected field: unexpected_field'
+        assert response.json['status'] == 'Error'
+        assert 'bad request' in response.json['description'].lower()
+        assert response.json['description'] == 'Bad request: unexpected field: unexpected_field'
 
     def test_request_expertise_with_invalid_and_missing_required_field(self, openreview_context, celery_session_app, celery_session_worker):
         # Submit a working config with an extra field that is not allowed
@@ -157,8 +160,9 @@ class TestExpertiseService():
             content_type='application/json'
         )
         assert response.status_code == 400, f'{response.json}'
-        assert 'bad request' in response.json['error'].lower()
-        assert response.json['error'] == 'Bad request: missing required field: name\nunexpected field: unexpected_field'
+        assert response.json['status'] == 'Error'
+        assert 'bad request' in response.json['description'].lower()
+        assert response.json['description'] == 'Bad request: missing required field: name\nunexpected field: unexpected_field'
 
     def test_request_expertise_with_invalid_model_param(self, openreview_context, celery_session_app, celery_session_worker):
         # Submit a working config with an extra model param field
@@ -182,8 +186,9 @@ class TestExpertiseService():
             content_type='application/json'
         )
         assert response.status_code == 400, f'{response.json}'
-        assert 'bad request' in response.json['error'].lower()
-        assert response.json['error'] == 'Bad request: unexpected model param: dummy_param'
+        assert response.json['status'] == 'Error'
+        assert 'bad request' in response.json['description'].lower()
+        assert response.json['description'] == 'Bad request: unexpected model param: dummy_param'
 
     def test_request_expertise_with_valid_parameters(self, openreview_context, celery_session_app, celery_session_worker):
         # Submit a working job and return the job ID

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -342,8 +342,13 @@ class TestExpertiseService():
         assert response['cdate'] <= response['mdate']
         ###assert os.path.isfile(f"{server_config['WORKING_DIR']}/{job_id}/err.log")
 
-        # Clean up error job
-        shutil.rmtree(f"./tests/jobs/{openreview_context['job_id']}")
+        # Clean up error job by calling the delete endpoint
+        response = test_client.get('/expertise/delete', query_string={'id': f"{openreview_context['job_id']}"}).json
+        assert response['name'] == 'test_run'
+        assert response['status'].strip() == 'Error'
+        assert response['description'] == 'use_title and use_abstract cannot both be False'
+        assert response['cdate'] <= response['mdate']
+        assert not os.path.isdir(f"./tests/jobs/{openreview_context['job_id']}")
     
     def test_high_load(self, openreview_context, celery_session_app, celery_session_worker):
         # Submit a working job and return the job ID

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -210,10 +210,9 @@ class TestExpertiseService():
         assert response.status_code == 200, f'{response.json}'
         job_id = response.json['job_id']
         time.sleep(2)
-        response = test_client.get('/expertise/status', query_string={'id': f'{job_id}'}).json['results']
-        assert len(response) == 1
-        assert response[0]['name'] == 'test_run'
-        assert response[0]['status'] != 'Error'
+        response = test_client.get('/expertise/status', query_string={'id': f'{job_id}'}).json
+        assert response['name'] == 'test_run'
+        assert response['status'] != 'Error'
         # assert response[0]['description'] == 'Server received config and allocated space'
 
         # # Attempt getting results of an incomplete job
@@ -231,24 +230,23 @@ class TestExpertiseService():
         # assert response[0]['description'] == 'Server received config and allocated space'
 
         # Query until job is complete
-        response = test_client.get('/expertise/status', query_string={'id': f'{job_id}'}).json['results']
-        assert len(response) == 1
+        response = test_client.get('/expertise/status', query_string={'id': f'{job_id}'}).json
         start_time = time.time()
         try_time = time.time() - start_time
-        while response[0]['status'] != 'Completed' and try_time <= MAX_TIMEOUT:
+        while response['status'] != 'Completed' and try_time <= MAX_TIMEOUT:
             time.sleep(5)
-            response = test_client.get('/expertise/status', query_string={'id': f'{job_id}'}).json['results']
-            if response[0]['status'] == 'Error':
-                assert False, response[0]['description']
+            response = test_client.get('/expertise/status', query_string={'id': f'{job_id}'}).json
+            if response['status'] == 'Error':
+                assert False, response['description']
             try_time = time.time() - start_time
 
         assert try_time <= MAX_TIMEOUT, 'Job has not completed in time'
-        assert response[0]['status'] == 'Completed'
-        assert response[0]['name'] == 'test_run'
-        assert response[0]['description'] == 'Job is complete and the computed scores are ready'
+        assert response['status'] == 'Completed'
+        assert response['name'] == 'test_run'
+        assert response['description'] == 'Job is complete and the computed scores are ready'
         
         # Check config fields
-        returned_config = response[0]['config']
+        returned_config = response['config']
         assert returned_config['name'] == 'test_run'
         assert returned_config['paper_invitation'] == 'ABC.cc/-/Submission'
         assert returned_config['model'] == 'elmo'
@@ -323,19 +321,18 @@ class TestExpertiseService():
         response = test_client.get('/expertise/results', query_string={'id': f"{openreview_context['job_id']}"})
         assert response.status_code == 404
 
-        response = test_client.get('/expertise/status', query_string={'id': f"{openreview_context['job_id']}"}).json['results']
-        assert len(response) == 1
+        response = test_client.get('/expertise/status', query_string={'id': f"{openreview_context['job_id']}"}).json
         start_time = time.time()
         try_time = time.time() - start_time
-        while response[0]['status'] == 'Processing' and try_time <= MAX_TIMEOUT:
+        while response['status'] == 'Processing' and try_time <= MAX_TIMEOUT:
             time.sleep(5)
-            response = test_client.get('/expertise/status', query_string={'id': f"{openreview_context['job_id']}"}).json['results']
+            response = test_client.get('/expertise/status', query_string={'id': f"{openreview_context['job_id']}"}).json
             try_time = time.time() - start_time
 
         assert try_time <= MAX_TIMEOUT, 'Job has not completed in time'
-        assert response[0]['name'] == 'test_run'
-        assert response[0]['status'].strip() == 'Error'
-        assert response[0]['description'] == 'use_title and use_abstract cannot both be False'
+        assert response['name'] == 'test_run'
+        assert response['status'].strip() == 'Error'
+        assert response['description'] == 'use_title and use_abstract cannot both be False'
         ###assert os.path.isfile(f"{server_config['WORKING_DIR']}/{job_id}/err.log")
 
         # Clean up error job
@@ -369,10 +366,9 @@ class TestExpertiseService():
             job_id = response.json['job_id']
             id_list.append(job_id)
             time.sleep(2)
-            response = test_client.get('/expertise/status', query_string={'id': f'{job_id}'}).json['results']
-            assert len(response) == 1
-            assert response[0]['name'] == 'test_run'
-            assert response[0]['status'] != 'Error'
+            response = test_client.get('/expertise/status', query_string={'id': f'{job_id}'}).json
+            assert response['name'] == 'test_run'
+            assert response['status'] != 'Error'
 
         assert id_list is not None
         openreview_context['job_id'] = id_list
@@ -386,29 +382,28 @@ class TestExpertiseService():
         last_job_id = id_list[num_requests - 1]
 
         # Assert that the last request completes
-        response = test_client.get('/expertise/status', query_string={'id': f'{last_job_id}'}).json['results']
-        assert len(response) == 1
+        response = test_client.get('/expertise/status', query_string={'id': f'{last_job_id}'}).json
         start_time = time.time()
         try_time = time.time() - start_time
-        while response[0]['status'] != 'Completed' and try_time <= MAX_TIMEOUT:
+        while response['status'] != 'Completed' and try_time <= MAX_TIMEOUT:
             time.sleep(5)
-            response = test_client.get('/expertise/status', query_string={'id': f'{last_job_id}'}).json['results']
-            if response[0]['status'] == 'Error':
-                assert False, response[0]['description']
+            response = test_client.get('/expertise/status', query_string={'id': f'{last_job_id}'}).json
+            if response['status'] == 'Error':
+                assert False, response['description']
             try_time = time.time() - start_time
 
         assert try_time <= MAX_TIMEOUT, 'Job has not completed in time'
-        assert response[0]['status'] == 'Completed'
-        assert response[0]['name'] == 'test_run'
-        assert response[0]['description'] == 'Job is complete and the computed scores are ready'
+        assert response['status'] == 'Completed'
+        assert response['name'] == 'test_run'
+        assert response['description'] == 'Job is complete and the computed scores are ready'
 
         # Now fetch and empty out all previous jobs
         for id in id_list:
             # Assert that they are complete
-            response = test_client.get('/expertise/status', query_string={'id': f'{id}'}).json['results']
-            assert response[0]['status'] == 'Completed'
-            assert response[0]['name'] == 'test_run'
-            assert response[0]['description'] == 'Job is complete and the computed scores are ready'
+            response = test_client.get('/expertise/status', query_string={'id': f'{id}'}).json
+            assert response['status'] == 'Completed'
+            assert response['name'] == 'test_run'
+            assert response['description'] == 'Job is complete and the computed scores are ready'
 
             response = test_client.get('/expertise/results', query_string={'id': f"{id}", 'delete_on_get': True})
             metadata = response.json['metadata']


### PR DESCRIPTION
Closes #73. Closes #74. Closes #82. Closes #81.

This solves the following leftover issues with the expertise API which are:
- Moving the default job config to the Flask config file
- Standardizes the error formatting to match the message returned from the `/expertise/status` endpoint