### PR TITLE
Fix CircleCI SPECTER

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             python --version
             mkdir ~/expertise-utils
             cd ~/expertise-utils
-            git clone https://github.com/allenai/specter.git
+            git clone https://github.com/haroldrubio/specter.git
             cd specter
             wget https://ai2-s2-research-public.s3-us-west-2.amazonaws.com/specter/archive.tar.gz
             tar -xzvf archive.tar.gz

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ conda install faiss-cpu -c pytorch
 
 If you plan to use SPECTER / SPECTER+MFR, with the conda environment `affinity` active:
 ```
-git clone https://github.com/allenai/specter.git
+git clone https://github.com/haroldrubio/specter.git
 cd specter
 
 wget https://ai2-s2-research-public.s3-us-west-2.amazonaws.com/specter/archive.tar.gz


### PR DESCRIPTION
The SPECTER repo uses a command to clone a repository that was deprecated by GitHub. This migrates the repo used to be a forked version that fixes this issue.