### PR TITLE
Revert config removal from /all

### DIFF
--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -182,7 +182,8 @@ class ExpertiseService(object):
                         'status': status,
                         'description': description,
                         'cdate': config.cdate,
-                        'mdate': config.mdate
+                        'mdate': config.mdate,
+                        'config': config.to_json()
                     }
                 )
         return result


### PR DESCRIPTION
Adds the config field back to the /status/all endpoint