### PR TITLE
Add GPU configuration to Expertise API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             python --version
             mkdir ~/expertise-utils
             cd ~/expertise-utils
-            git clone https://github.com/haroldrubio/specter.git
+            git clone https://github.com/allenai/specter.git
             cd specter
             wget https://ai2-s2-research-public.s3-us-west-2.amazonaws.com/specter/archive.tar.gz
             tar -xzvf archive.tar.gz

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ conda install faiss-cpu -c pytorch
 
 If you plan to use SPECTER / SPECTER+MFR, with the conda environment `affinity` active:
 ```
-git clone https://github.com/haroldrubio/specter.git
+git clone https://github.com/allenai/specter.git
 cd specter
 
 wget https://ai2-s2-research-public.s3-us-west-2.amazonaws.com/specter/archive.tar.gz

--- a/expertise/service/config/default.cfg
+++ b/expertise/service/config/default.cfg
@@ -11,7 +11,8 @@ DEFAULT_CONFIG = {
     "model": "specter+mfr",
     "model_params": {
         "use_title": True,
-        "batch_size": 4,
+        "specter_batch_size": 16,
+        "mfr_batch_size": 50,
         "use_abstract": True,
         "average_score": False,
         "max_score": True,

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -446,7 +446,8 @@ class JobConfig(object):
         config.model_params['average_score'] = model_params.get('average_score', None)
         config.model_params['max_score'] = model_params.get('max_score', None)
         config.model_params['skip_specter'] = model_params.get('skip_specter', None)
-        config.model_params['batch_size'] = model_params.get('batch_size', 1)
+        config.model_params['specter_batch_size'] = model_params.get('specter_batch_size', 16)
+        config.model_params['mfr_batch_size'] = model_params.get('mfr_batch_size', 50)
         config.model_params['use_cuda'] = model_params.get('use_cuda', False)
 
         # Attempt to load any API request model params


### PR DESCRIPTION
- Updates model parameter validation to support separate SPECTER + MFR batch sizes

- Deprecates `batch_size` parameter as it is not used in SPECTER + MFR

- Replaces `haroldrubio/specter.git` with `allenai/specter.git`