### PR TITLE
Allow blind publications for expertise

### DIFF
--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -58,10 +58,10 @@ class OpenReviewExpertise(object):
         deduplicated = []
 
         # Build index of pub.original
-        original_ids = [getattr(pub, 'original', None) for pub in publications]
+        original_ids = [pub.original for pub in publications]
 
         for pub in publications:
-            note_id, original_id = pub.id, getattr(pub, 'original', None)
+            note_id, original_id = pub.id, pub.original
             # If original note, but blind already exists, skip the original note
             if original_id is None and note_id in original_ids:
                 continue

--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -57,13 +57,13 @@ class OpenReviewExpertise(object):
     def deduplicate_publications(self, publications):
         deduplicated = []
 
-        # Build index of publication IDs
-        pub_ids = [pub.id for pub in publications]
+        # Build index of pub.original
+        original_ids = [getattr(pub, 'original', None) for pub in publications]
 
         for pub in publications:
-            original = getattr(pub, 'original', None)
-            # If blind note, but the original already exists, skip this
-            if original is not None and original in pub_ids:
+            note_id, original_id = pub.id, getattr(pub, 'original', None)
+            # If original note, but blind already exists, skip the original note
+            if original_id is None and note_id in original_ids:
                 continue
 
             # Otherwise, keep this note

--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -73,9 +73,6 @@ class OpenReviewExpertise(object):
             if self.config.get('dataset', {}).get('with_title', False):
                 if not 'title' in publication.content or not publication.content.get('title'):
                     continue
-            # Exclude blind Notes
-            if getattr(publication, 'original', None) is not None:
-                continue
             if getattr(publication, 'cdate') is None:
                 publication.cdate = getattr(publication, 'tcdate', 0)
 

--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -58,7 +58,7 @@ class OpenReviewExpertise(object):
         deduplicated = []
 
         # Build index of pub.original
-        original_ids = [pub.original for pub in publications]
+        original_ids = {pub.original for pub in publications if pub.original is not None}
 
         for pub in publications:
             # Keep all blind notes, and keep originals that do not have a corresponding blind

--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -334,7 +334,9 @@ class OpenReviewExpertise(object):
             pbar.update(1)
             profile = openreview.tools.get_profile(client, profile_id)
             if profile:
-                publications = list(openreview.tools.iterget_notes(self.openreview_client, content={'authorids': profile.id}))
+                publications = self.deduplicate_publications(
+                    list(openreview.tools.iterget_notes(self.openreview_client, content={'authorids': profile.id}))
+                )
                 return { 'profile_id': profile_id, 'papers': publications }
         futures = []
         with ThreadPoolExecutor(max_workers=self.config.get('max_workers')) as executor:

--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -61,13 +61,9 @@ class OpenReviewExpertise(object):
         original_ids = [pub.original for pub in publications]
 
         for pub in publications:
-            note_id, original_id = pub.id, pub.original
-            # If original note, but blind already exists, skip the original note
-            if original_id is None and note_id in original_ids:
-                continue
-
-            # Otherwise, keep this note
-            deduplicated.append(pub)
+            # Keep all blind notes, and keep originals that do not have a corresponding blind
+            if pub.id not in original_ids:
+                deduplicated.append(pub)
         
         return deduplicated
 

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 from enum import Enum
 
 import re
-SUPERUSER_IDS = ['openreview.net']
+SUPERUSER_IDS = ['openreview.net', 'OpenReview.net', '~Super_User1']
 
 # -----------------
 # -- Mock Client --

--- a/tests/data/fakeData.json
+++ b/tests/data/fakeData.json
@@ -2398,6 +2398,15 @@
           "title": "Drainage of R Post Tib Art with Drain Dev, Perc Approach",
           "abstract": "Phasellus in felis. Donec semper sapien a libero. Nam dui."
         }
+      },
+      {
+        "id": "t8WTbHVh",
+        "cdate": 1568425952,
+        "original": "T8wtBhvH",
+        "content": {
+          "title": "Drainage of R Post Tib Art with Drain Dev, Perc Approach",
+          "abstract": "Phasellus in felis. Donec semper sapien a libero. Nam dui."
+        }
       }
     ]
   }, {

--- a/tests/test_create_dataset.py
+++ b/tests/test_create_dataset.py
@@ -291,7 +291,10 @@ def test_retrieve_expertise(get_paperhash):
     profiles = data['profiles']
     for profile in profiles:
         if len(profile['publications']) > 0:
-            assert len(expertise[profile['id']]) == len(profile['publications'])
+            if profile.id == '~Perry_Volkman3':
+                assert len(expertise[profile['id']]) > len(profile['publications'])
+            else:
+                assert len(expertise[profile['id']]) == len(profile['publications'])
 
 def test_get_submissions_from_invitation():
     openreview_client = mock_client()

--- a/tests/test_create_dataset.py
+++ b/tests/test_create_dataset.py
@@ -291,8 +291,8 @@ def test_retrieve_expertise(get_paperhash):
     profiles = data['profiles']
     for profile in profiles:
         if len(profile['publications']) > 0:
-            if profile.id == '~Perry_Volkman3':
-                assert len(expertise[profile['id']]) > len(profile['publications'])
+            if profile['id'] == '~Perry_Volkman3':
+                assert len(expertise[profile['id']]) < len(profile['publications'])
             else:
                 assert len(expertise[profile['id']]) == len(profile['publications'])
 


### PR DESCRIPTION
- Resolves #112

Removes the check for only original notes and adds an additional deduplication step when retrieving a reviewer's expertise.

