### PR TITLE
Feature/Add publication date and default sparse value

### DIFF
--- a/tests/test_create_conference.py
+++ b/tests/test_create_conference.py
@@ -221,13 +221,13 @@ class TestConference():
                         "required": False,
                         "order": 3,
                         "description": "Comma separated list of author names, as they appear in the paper.",
-                        "value-regex": "[^,\\n]*(,[^,\\n]+)*"
+                        "values-regex": "[^,\\n]*(,[^,\\n]+)*"
                     },
                     "authorids": {
                         "required": False,
                         "order": 4,
                         "description": "Comma separated list of author email addresses, in the same order as above.",
-                        "value-regex": "[^,\\n]*(,[^,\\n]+)*"
+                        "values-regex": "[^,\\n]*(,[^,\\n]+)*"
                     }
                 }
             }
@@ -248,7 +248,7 @@ class TestConference():
         assert client.get_invitation('openreview.net/-/paper')
 
     def test_post_submissions(self, client, openreview_client, helpers):
-        
+
         def post_notes(data, invitation):
             test_user_client = openreview.Client(username='test@google.com', password='1234')
             for note_json in data['notes'][invitation]:
@@ -314,28 +314,30 @@ class TestConference():
         helpers.await_queue()
 
     def test_post_publications(self, client, openreview_client):
+        tmlr_editors = ['~Raia_Hadsell1', '~Kyunghyun_Cho1']
 
         def post_notes(data, api_invitation):
             for profile_json in data['profiles']:
                 authorid = profile_json['id']
-                for pub_json in profile_json['publications']:
-                    content = pub_json['content']
-                    content['authorids'] = [authorid]
-                    cdate = pub_json.get('cdate')
+                if authorid not in tmlr_editors:
+                    for pub_json in profile_json['publications']:
+                        content = pub_json['content']
+                        content['authorids'] = [authorid]
+                        cdate = pub_json.get('cdate')
 
-                    existing_pubs = list(openreview.tools.iterget_notes(client, content={'authorids': authorid}))
-                    existing_titles = [pub.content.get('title') for pub in existing_pubs]
+                        existing_pubs = list(openreview.tools.iterget_notes(client, content={'authorids': authorid}))
+                        existing_titles = [pub.content.get('title') for pub in existing_pubs]
 
-                    if content.get('title') not in existing_titles:
-                        note = openreview.Note(
-                            invitation = api_invitation,
-                            readers = ['everyone'],
-                            writers = ['~SomeTest_User1'],
-                            signatures = ['~SomeTest_User1'],
-                            content = content,
-                            cdate = cdate
-                        )
-                        note = client.post_note(note)
+                        if content.get('title') not in existing_titles:
+                            note = openreview.Note(
+                                invitation = api_invitation,
+                                readers = ['everyone'],
+                                writers = ['~SomeTest_User1'],
+                                signatures = ['~SomeTest_User1'],
+                                content = content,
+                                cdate = cdate
+                            )
+                            note = client.post_note(note)
 
         with open('tests/data/fakeData.json') as json_file:
             data = json.load(json_file)

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -355,6 +355,9 @@ class TestExpertiseService():
                             'useAbstract': True, 
                             'skipSpecter': False,
                             'scoreComputation': 'avg'
+                    },
+                    "dataset": {
+                        'minimumPubDate': 0
                     }
                 }
             ),
@@ -402,6 +405,7 @@ class TestExpertiseService():
         assert response['status'] == 'Completed'
         assert response['name'] == 'test_run'
         assert response['description'] == 'Job is complete and the computed scores are ready'
+        assert os.path.getsize(f"./tests/jobs/{job_id}/test_run.csv") == os.path.getsize(f"./tests/jobs/{job_id}/test_run_sparse.csv")
 
         # Check for API request
         req = response['request']
@@ -410,6 +414,9 @@ class TestExpertiseService():
         assert req['entityA']['memberOf'] == 'ABC.cc/Reviewers'
         assert req['entityB']['type'] == 'Note'
         assert req['entityB']['invitation'] == 'ABC.cc/-/Submission'
+        assert 'model' in req.keys()
+        assert 'dataset' in req.keys()
+        assert req['dataset']['minimumPubDate'] == 0
         assert response['cdate'] <= response['mdate']
 
         # After completion, check for non-empty completed list


### PR DESCRIPTION
Resolves
- #128 

The expertise API now retrieves sparse values by default, unless indicated by a `group_scoring` flag which retrieves the original scores as this file was post-processed after scores were computed (the sparse file will still have user-paper scores)

This PR also adds support for an additional `dataset` field to the API request schema expand the amount of supported dataset keywords more easily.