### PR TITLE
Only return dataset if it exists

### DIFF
--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -132,8 +132,9 @@ class APIRequest(object):
 
         if len(self.model.keys()) > 0:
             body['model'] = self.model
-        if len(self.dataset.keys()) > 0:
-            body['dataset'] = self.dataset
+        if hasattr(self, 'dataset'):
+            if len(self.dataset.keys()) > 0:
+                body['dataset'] = self.dataset
 
         return body
 


### PR DESCRIPTION
Fix a backwards compatibility error - only fetches dataset attribute if it exists