### PR TITLE
Skip expertise selection if not exist

### DIFF
--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -347,13 +347,14 @@ class JobConfig(object):
                 try:
                     inv = openreview_client.get_invitation(edge_inv_id)
                 except:
-                    raise openreview.OpenReviewException(f"Not found: Expertise invitation {edge_inv_id} does not exist")
-
-                label = inv.reply.get('content', {}).get('label', {}).get('value-radio',['Include'])[0]
-                if 'exclude' not in label.lower():
-                    config.inclusion_inv = edge_inv_id
-                else:
-                    config.exclusion_inv = edge_inv_id
+                    inv = None
+                
+                if inv:
+                    label = inv.reply.get('content', {}).get('label', {}).get('value-radio',['Include'])[0]
+                    if 'exclude' not in label.lower():
+                        config.inclusion_inv = edge_inv_id
+                    else:
+                        config.exclusion_inv = edge_inv_id
 
         if api_request.entityB['type'] == 'Group':
             config.alternate_match_group = [api_request.entityB['memberOf']]
@@ -369,13 +370,14 @@ class JobConfig(object):
                 try:
                     inv = openreview_client.get_invitation(edge_inv_id)
                 except:
-                    raise openreview.OpenReviewException(f"Not found: Expertise invitation {edge_inv_id} does not exist")
-
-                label = inv.reply.get('content', {}).get('label', {}).get('value-radio',['Include'])[0]
-                if 'include' in label.lower():
-                    config.alternate_inclusion_inv = edge_inv_id
-                else:
-                    config.alternate_exclusion_inv = edge_inv_id
+                    inv = None
+                
+                if inv:
+                    label = inv.reply.get('content', {}).get('label', {}).get('value-radio',['Include'])[0]
+                    if 'include' in label.lower():
+                        config.alternate_inclusion_inv = edge_inv_id
+                    else:
+                        config.alternate_exclusion_inv = edge_inv_id
 
         # Handle Note cases
         config.paper_invitation = None

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -343,7 +343,13 @@ class JobConfig(object):
                     edge_inv_id = edge_inv.get('invitation', None)
                 if edge_inv_id is None or len(edge_inv_id) <= 0:
                     raise openreview.OpenReviewException('Bad request: Expertise invitation indicated but ID not provided')
-                label = openreview_client.get_invitation(edge_inv_id).reply.get('content', {}).get('label', {}).get('value-radio',['Include'])[0]
+
+                try:
+                    inv = openreview_client.get_invitation(edge_inv_id)
+                except:
+                    raise openreview.OpenReviewException(f"Not found: Expertise invitation {edge_inv_id} does not exist")
+
+                label = inv.reply.get('content', {}).get('label', {}).get('value-radio',['Include'])[0]
                 if 'exclude' not in label.lower():
                     config.inclusion_inv = edge_inv_id
                 else:
@@ -359,7 +365,13 @@ class JobConfig(object):
                     edge_inv_id = edge_inv.get('invitation', None)
                 if edge_inv_id is None:
                     raise openreview.OpenReviewException('Bad request: Expertise invitation indicated but ID not provided')
-                label = openreview_client.get_invitation(edge_inv_id).reply.get('content', {}).get('label', {}).get('value-radio',['Include'])[0]
+
+                try:
+                    inv = openreview_client.get_invitation(edge_inv_id)
+                except:
+                    raise openreview.OpenReviewException(f"Not found: Expertise invitation {edge_inv_id} does not exist")
+
+                label = inv.reply.get('content', {}).get('label', {}).get('value-radio',['Include'])[0]
                 if 'include' in label.lower():
                     config.alternate_inclusion_inv = edge_inv_id
                 else:


### PR DESCRIPTION
This PR catches if the provided invitation does not exist - in this case, the API will treat the job as if no invitation was provided.