### PR TITLE
Fix Specter cache

### DIFF
--- a/expertise/models/multifacet_recommender/specter.py
+++ b/expertise/models/multifacet_recommender/specter.py
@@ -116,6 +116,7 @@ class _PredictManagerCustom(_PredictManager):
             paper_id = prediction_json['paper_id']
             cache_key = paper_id + "_" + str(self._metadata[paper_id]['mdate'])
             self._redis_con.tensorset(key=cache_key, tensor=np.array(prediction_json['embedding']))
+            self._redis_con.expire(cache_key, 2629746) ## Expire after 1 month
 
 
 def predictor_from_archive(archive: Archive, predictor_name: str = None,

--- a/expertise/models/multifacet_recommender/specter.py
+++ b/expertise/models/multifacet_recommender/specter.py
@@ -211,7 +211,6 @@ class SpecterPredictor:
                                 "authors": [profile_id],
                                 "mdate": pub_mdate
                             }
-                        self._remove_keys_from_cache(publication["id"])
                 else:
                     print(f"Skipping publication {publication['id']}. Either title or abstract must be provided ")
         with open(os.path.join(self.work_dir, "specter_reviewer_paper_data.json"), 'w') as f_out:

--- a/expertise/service/config/default.cfg
+++ b/expertise/service/config/default.cfg
@@ -22,6 +22,6 @@ DEFAULT_CONFIG = {
         "max_score": True,
         "skip_specter": False,
         "use_cuda": False,
-        "use_redis": False
+        "use_redis": True
     }
 }

--- a/tests/test_spectermfr.py
+++ b/tests/test_spectermfr.py
@@ -179,6 +179,5 @@ def test_specter_scores_updated_mdate(tmp_path, create_specter):
             paper_data = json.loads(line.rstrip())
             paper_id = paper_data['paper_id']
             paper_embedding = numpy.array(paper_data['embedding'])
-            assert not redis_con.exists(paper_id + "_1234567890")
             paper_emb_redis = redis_con.tensorget(paper_id + "_2345678901", as_numpy_mutable=True)
             assert numpy.all(paper_emb_redis == paper_embedding)


### PR DESCRIPTION
This PR no longer attempts to find and remove all old instances of publications in the Redis cache, and instead sets an expiration date whenever inserting into Redis.