### PR TITLE
Cancels jobs that were running on server restart

### DIFF
--- a/expertise/service/__init__.py
+++ b/expertise/service/__init__.py
@@ -5,6 +5,7 @@ import redis
 import time
 
 from celery import Celery
+from celery.app.control import Control
 from expertise.service.utils import JobStatus, JobDescription, RedisDatabase
 
 def configure_logger(app):
@@ -72,26 +73,85 @@ def create_app(config=None):
     app.logger.info('Running server startup code')
     for config in redis.load_all_jobs('~Super_User1'):
         status = config.status
-        if status == JobStatus.RUN_EXPERTISE or status == JobStatus.FETCHING_DATA:
+        if status in [
+            JobStatus.QUEUED,
+            JobStatus.FETCHING_DATA,
+            JobStatus.EXPERTISE_QUEUED,
+            JobStatus.RUN_EXPERTISE
+        ]:
             app.logger.info(f"{config.job_id} was running - canceling job")
-            config.status = JobStatus.CANCEL
-            config.description = JobDescription.VALS[JobStatus.CANCEL]
+            config.status = JobStatus.ERROR
+            config.description = 'Server restarted while job was running'
             config.mdate = int(time.time() * 1000)
             redis.save_job(config)
 
     return app
 
-
 def create_celery(app):
     """
     Initializes a celery application using Flask App
     """
+
+    def set_config_error(job_config):
+        status = job_config.status
+        if status in [
+            JobStatus.QUEUED,
+            JobStatus.FETCHING_DATA,
+            JobStatus.EXPERTISE_QUEUED,
+            JobStatus.RUN_EXPERTISE
+        ]:
+            app.logger.info(f"{job_config.job_id} was running - canceling job")
+            job_config.status = JobStatus.ERROR
+            job_config.description = 'Server restarted while job was running'
+            job_config.mdate = int(time.time() * 1000)
+            redis.save_job(job_config)
+
     config_source = app.config["CELERY_CONFIG"]
     celery = Celery(
         app.import_name,
         include=["expertise.service.celery_tasks"],
         config_source=config_source
     )
+
+    # Clear the celery queues
+    redis_config_pool, _ = create_redis(app)
+    redis = RedisDatabase(
+        connection_pool=redis_config_pool
+    )
+
+    app.logger.info('Running celery startup code')
+    control = Control(celery)
+    inspect = control.inspect()
+    active = inspect.active()
+    scheduled = inspect.scheduled()
+    reserved = inspect.reserved()
+
+    app.logger.info('Active queue:')
+    app.logger.info(active)
+    if active:
+        for job_list in active.values():
+            for job in job_list:
+                app.logger.info(f"Revoking task {job['id']} with terminate signal")
+                control.revoke(job['id'], terminate=True)
+                set_config_error(job['args'][0])
+
+    app.logger.info('Scheduled queue:')
+    app.logger.info(scheduled)
+    if scheduled:
+        for job_list in scheduled.values():
+            for job in job_list:
+                app.logger.info(f"Revoking task {job['id']}")
+                control.revoke(job['id'])
+                set_config_error(job['args'][0])
+
+    app.logger.info('Reserved queue:')
+    app.logger.info(reserved)
+    if reserved:
+        for job_list in reserved.values():
+            for job in job_list:
+                app.logger.info(f"Revoking task {job['id']}")
+                control.revoke(job['id'])
+                set_config_error(job['args'][0])
 
     return celery
 

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -38,6 +38,7 @@ class JobStatus(str, Enum):
     RUN_EXPERTISE = 'Running Expertise'
     COMPLETED = 'Completed'
     ERROR = 'Error'
+    CANCEL = 'Canceled'
 
 class JobDescription(dict, Enum):
     VALS = {
@@ -47,6 +48,7 @@ class JobDescription(dict, Enum):
         JobStatus.EXPERTISE_QUEUED: 'Job has assembled the data and is waiting in queue for the expertise model',
         JobStatus.RUN_EXPERTISE: 'Job is running the selected expertise model to compute scores',
         JobStatus.COMPLETED: 'Job is complete and the computed scores are ready',
+        JobStatus.CANCEL: 'Job was running when the server restarted and was canceled'
     }
 class APIRequest(object):
     """


### PR DESCRIPTION
This PR adds additional startup code to Flask and Celery that marks all jobs running at the time of a server restart with ERROR which will cause process functions to fail while clearing the Celery queue.