### PR TITLE
Clean jobs script

### DIFF
--- a/clean_jobs.sh
+++ b/clean_jobs.sh
@@ -1,0 +1,3 @@
+find /home/openreview/openreview-expertise/jobs/*/mfr -prune -type d -mtime +0.168 -exec rm -r {} \;
+find /home/openreview/openreview-expertise/jobs/*/specter -prune -type d -mtime +0.168 -exec rm -r {} \;
+find /home/openreview/openreview-expertise/jobs/*/sub2vec.jsonl -prune -mtime +0.168 -exec rm -r {} \;

--- a/clean_jobs.sh
+++ b/clean_jobs.sh
@@ -1,3 +1,7 @@
-find /home/openreview/openreview-expertise/jobs/*/mfr -prune -type d -mtime +0.168 -exec rm -r {} \;
-find /home/openreview/openreview-expertise/jobs/*/specter -prune -type d -mtime +0.168 -exec rm -r {} \;
-find /home/openreview/openreview-expertise/jobs/*/sub2vec.jsonl -prune -mtime +0.168 -exec rm -r {} \;
+find /home/openreview/openreview-expertise/jobs/*/archives -prune -type d -mtime +30 -exec rm -r {} \;
+find /home/openreview/openreview-expertise/jobs/*/mfr -prune -type d -mtime +30 -exec rm -r {} \;
+find /home/openreview/openreview-expertise/jobs/*/specter -prune -type d -mtime +30 -exec rm -r {} \;
+find /home/openreview/openreview-expertise/jobs/*/sub2vec.jsonl -prune -mtime +30 -exec rm -r {} \;
+find /home/openreview/openreview-expertise/jobs/*/metadata.json -prune -mtime +30 -exec rm -r {} \;
+find /home/openreview/openreview-expertise/jobs/*/submissions.json -prune -mtime +30 -exec rm -r {} \;
+find /home/openreview/openreview-expertise/jobs/*/pub2vec.jsonl -prune -mtime +30 -exec rm -r {} \;


### PR DESCRIPTION
This script will be set on a cron job and is used to remove job data except for the config file and score file(s) for jobs older than a month.