### PR TITLE
Check edge label

### DIFF
--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -245,7 +245,7 @@ class OpenReviewExpertise(object):
                 self.openreview_client,
                 invitation=invitation,
                 groupby='tail',
-                select='id,head,label,weight,label'
+                select='id,head,label,weight'
             )
 
             for edges in user_grouped_edges:

--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -256,72 +256,16 @@ class OpenReviewExpertise(object):
         return selected_ids_by_user
 
     def exclude(self):
-        exclusion_invitations = self.convert_to_list(self.config['exclusion_inv'])
-        excluded_ids_by_user = defaultdict(list)
-        for invitation in exclusion_invitations:
-            user_grouped_edges = openreview.tools.iterget_grouped_edges(
-                self.openreview_client,
-                invitation=invitation,
-                groupby='tail',
-                select='id,head,label,weight'
-            )
-
-            for edges in user_grouped_edges:
-                for edge in edges:
-                    excluded_ids_by_user[edge.tail].append(edge.head)
-
-        return excluded_ids_by_user
+        return self.get_expertise_selection_edges('exclusion_inv', 'Exclude')
     
     def alternate_exclude(self):
-        exclusion_invitations = self.convert_to_list(self.config['alternate_exclusion_inv'])
-        excluded_ids_by_user = defaultdict(list)
-        for invitation in exclusion_invitations:
-            user_grouped_edges = openreview.tools.iterget_grouped_edges(
-                self.openreview_client,
-                invitation=invitation,
-                groupby='tail',
-                select='id,head,label,weight'
-            )
-
-            for edges in user_grouped_edges:
-                for edge in edges:
-                    excluded_ids_by_user[edge.tail].append(edge.head)
-
-        return excluded_ids_by_user
+        return self.get_expertise_selection_edges('alternate_exclusion_inv', 'Exclude')
     
     def include(self):
-        inclusion_invitations = self.convert_to_list(self.config['inclusion_inv'])
-        included_ids_by_user = defaultdict(list)
-        for invitation in inclusion_invitations:
-            user_grouped_edges = openreview.tools.iterget_grouped_edges(
-                self.openreview_client,
-                invitation=invitation,
-                groupby='tail',
-                select='id,head,label,weight'
-            )
-
-            for edges in user_grouped_edges:
-                for edge in edges:
-                    included_ids_by_user[edge.tail].append(edge.head)
-
-        return included_ids_by_user
+        return self.get_expertise_selection_edges('inclusion_inv', 'Include')
     
     def alternate_include(self):
-        inclusion_invitations = self.convert_to_list(self.config['alternate_inclusion_inv'])
-        included_ids_by_user = defaultdict(list)
-        for invitation in inclusion_invitations:
-            user_grouped_edges = openreview.tools.iterget_grouped_edges(
-                self.openreview_client,
-                invitation=invitation,
-                groupby='tail',
-                select='id,head,label,weight'
-            )
-
-            for edges in user_grouped_edges:
-                for edge in edges:
-                    included_ids_by_user[edge.tail].append(edge.head)
-
-        return included_ids_by_user
+        return self.get_expertise_selection_edges('alternate_inclusion_inv', 'Include')
 
     def retrieve_expertise_helper(self, member, email):
         self.pbar.update(1)

--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -237,6 +237,24 @@ class OpenReviewExpertise(object):
 
         return valid_members, invalid_members
 
+    def get_expertise_selection_edges(self, invitation_key, label=None):
+        edge_invitations = self.convert_to_list(self.config[invitation_key])
+        selected_ids_by_user = defaultdict(list)
+        for invitation in edge_invitations:
+            user_grouped_edges = openreview.tools.iterget_grouped_edges(
+                self.openreview_client,
+                invitation=invitation,
+                groupby='tail',
+                select='id,head,label,weight,label'
+            )
+
+            for edges in user_grouped_edges:
+                for edge in edges:
+                    if not label or (label and edge.label == label):
+                        selected_ids_by_user[edge.tail].append(edge.head)
+
+        return selected_ids_by_user
+
     def exclude(self):
         exclusion_invitations = self.convert_to_list(self.config['exclusion_inv'])
         excluded_ids_by_user = defaultdict(list)


### PR DESCRIPTION
- Resolves #139 

This PR slightly refactors the code for getting expertise selection edges and only adds edges whose labels match with the invitation