### PR TITLE
Query by Paper ID and Match Group

### DIFF
--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -189,7 +189,7 @@ class ExpertiseService(object):
             return not search_invitation or inv.lower().startswith(search_invitation.lower())
 
         def check_paper_id():
-            paper_id = config.api_request.entityA.get('id') or config.api_request.entityB.get('id')
+            paper_id = config.api_request.entityA.get('id', '') or config.api_request.entityB.get('id', '')
             return not search_paper_id or paper_id.lower().startswith(search_paper_id.lower())
 
         def check_result():

--- a/expertise/service/routes.py
+++ b/expertise/service/routes.py
@@ -142,8 +142,9 @@ def jobs():
         # Parse query parameters
         job_id = flask.request.args.get('jobId', None)
         if job_id is None or len(job_id) == 0:
-            raise openreview.OpenReviewException('Bad request: jobId is required')
-        result = ExpertiseService(openreview_client, flask.current_app.config, flask.current_app.logger).get_expertise_status(user_id, job_id)
+            result = ExpertiseService(openreview_client, flask.current_app.config, flask.current_app.logger).get_expertise_all_status(user_id, flask.request.args)
+        else:
+            result = ExpertiseService(openreview_client, flask.current_app.config, flask.current_app.logger).get_expertise_status(user_id, job_id)
         flask.current_app.logger.debug('GET returns ' + str(result))
         return flask.jsonify(result), 200
 

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -173,7 +173,6 @@ class RedisDatabase(object):
 
             if not os.path.isdir(current_config.job_dir):
                 print(f"No files found {job_key} - skipping")
-                self.remove_job(user_id, current_config.job_id)
                 continue
 
             if current_config.user_id == user_id or user_id in SUPERUSER_IDS:

--- a/tests/test_create_journal.py
+++ b/tests/test_create_journal.py
@@ -36,6 +36,7 @@ class TestJournal():
         journal.setup(support_role='fabian@mail.com', editors=['~Raia_Hadsell1', '~Kyunghyun_Cho1'])
 
         openreview_client.add_members_to_group('TMLR/Action_Editors', ['~Raia_Hadsell1', '~Kyunghyun_Cho1'])
+        openreview_client.add_members_to_group('TMLR/Reviewers', ['~Raia_Hadsell1', '~Kyunghyun_Cho1'])
     
     def test_post_submissions(self, client, openreview_client, helpers):
         # Post submission with a test author id

--- a/tests/test_expertise_apiv2.py
+++ b/tests/test_expertise_apiv2.py
@@ -270,6 +270,15 @@ class TestExpertiseV2():
         response = test_client.get('/expertise/status', query_string={'paperId': target_id, 'memberOf': 'TMLR/Reviewers'}).json['results']
         assert len(response) == 1
 
+        response = test_client.get('/expertise/status', query_string={'entityB.paperId': target_id, 'memberOf': 'TMLR/Reviewers'}).json['results']
+        assert len(response) == 1
+
+        response = test_client.get('/expertise/status', query_string={'entityB.paperId': target_id, 'entityB.memberOf': 'TMLR/Reviewers'}).json['results']
+        assert len(response) == 0
+
+        response = test_client.get('/expertise/status', query_string={'entityA.paperId': target_id}).json['results']
+        assert len(response) == 0
+
         response = test_client.get('/expertise/status', query_string={'paperId': 'DoesNotExist'}).json['results']
         assert len(response) == 0
 

--- a/tests/test_expertise_apiv2.py
+++ b/tests/test_expertise_apiv2.py
@@ -212,15 +212,69 @@ class TestExpertiseV2():
         assert req['entityB']['type'] == 'Note'
         assert req['entityB']['id'] == target_id
 
+        openreview_context['job_id'] = job_id
+
+        # Make a request for TMLR/Reviewers
+        response = test_client.post(
+            '/expertise',
+            data = json.dumps({
+                    "name": "test_run",
+                    "entityA": {
+                        'type': "Group",
+                        'memberOf': "TMLR/Reviewers",
+                    },
+                    "entityB": { 
+                        'type': "Note",
+                        'id': target_id
+                    },
+                    "model": {
+                            "name": "specter+mfr",
+                            'useTitle': False, 
+                            'useAbstract': True, 
+                            'skipSpecter': False,
+                            'scoreComputation': 'avg'
+                    }
+                }
+            ),
+            content_type='application/json',
+            headers=openreview_client.headers
+        )
+        assert response.status_code == 200, f'{response.json}'
+        job_id = response.json['jobId']
+        time.sleep(2)
+        response = test_client.get('/expertise/status', query_string={'jobId': f'{job_id}'}).json
+        assert response['name'] == 'test_run'
+        assert response['status'] != 'Error'
+
+        # Query until job is complete
+        response = test_client.get('/expertise/status', query_string={'jobId': f'{job_id}'}).json
+        start_time = time.time()
+        try_time = time.time() - start_time
+        while response['status'] != 'Completed' and try_time <= MAX_TIMEOUT:
+            time.sleep(5)
+            response = test_client.get('/expertise/status', query_string={'jobId': f'{job_id}'}).json
+            if response['status'] == 'Error':
+                assert False, response[0]['description']
+            try_time = time.time() - start_time
+
+        assert try_time <= MAX_TIMEOUT, 'Job has not completed in time'
+        assert response['status'] == 'Completed'
+        assert response['name'] == 'test_run'
+        assert response['description'] == 'Job is complete and the computed scores are ready'
+
         # Test for paper id query
         response = test_client.get('/expertise/status/all', query_string={'paperId': target_id}).json['results']
+        assert len(response) == 2
+
+        # Test for paper id and member of query
+        response = test_client.get('/expertise/status/all', query_string={'paperId': target_id, 'memberOf': 'TMLR/Reviewers'}).json['results']
         assert len(response) == 1
-        assert response[0]['request']['entityA']['memberOf'] == 'TMLR/Action_Editors'
 
         response = test_client.get('/expertise/status/all', query_string={'paperId': 'DoesNotExist'}).json['results']
         assert len(response) == 0
 
-        openreview_context['job_id'] = job_id
+        response = test_client.get('/expertise/results', query_string={'jobId': f'{job_id}', 'deleteOnGet': True})
+        assert not os.path.isdir(f"./tests/jobs/{job_id}")
 
     def test_get_journal_results(self, openreview_context, celery_session_app, celery_session_worker):
         test_client = openreview_context['test_client']

--- a/tests/test_expertise_apiv2.py
+++ b/tests/test_expertise_apiv2.py
@@ -263,14 +263,14 @@ class TestExpertiseV2():
         assert response['description'] == 'Job is complete and the computed scores are ready'
 
         # Test for paper id query
-        response = test_client.get('/expertise/status/all', query_string={'paperId': target_id}).json['results']
+        response = test_client.get('/expertise/status', query_string={'paperId': target_id}).json['results']
         assert len(response) == 2
 
         # Test for paper id and member of query
-        response = test_client.get('/expertise/status/all', query_string={'paperId': target_id, 'memberOf': 'TMLR/Reviewers'}).json['results']
+        response = test_client.get('/expertise/status', query_string={'paperId': target_id, 'memberOf': 'TMLR/Reviewers'}).json['results']
         assert len(response) == 1
 
-        response = test_client.get('/expertise/status/all', query_string={'paperId': 'DoesNotExist'}).json['results']
+        response = test_client.get('/expertise/status', query_string={'paperId': 'DoesNotExist'}).json['results']
         assert len(response) == 0
 
         response = test_client.get('/expertise/results', query_string={'jobId': f'{job_id}', 'deleteOnGet': True})

--- a/tests/test_expertise_apiv2.py
+++ b/tests/test_expertise_apiv2.py
@@ -211,6 +211,15 @@ class TestExpertiseV2():
         assert req['entityA']['memberOf'] == 'TMLR/Action_Editors'
         assert req['entityB']['type'] == 'Note'
         assert req['entityB']['id'] == target_id
+
+        # Test for paper id query
+        response = test_client.get('/expertise/status/all', query_string={'paperId': target_id}).json['results']
+        assert len(response) == 1
+        assert response[0]['request']['entityA']['memberOf'] == 'TMLR/Action_Editors'
+
+        response = test_client.get('/expertise/status/all', query_string={'paperId': 'DoesNotExist'}).json['results']
+        assert len(response) == 0
+
         openreview_context['job_id'] = job_id
 
     def test_get_journal_results(self, openreview_context, celery_session_app, celery_session_worker):

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -534,17 +534,6 @@ class TestExpertiseService():
         response = test_client.get('/expertise/status/all', query_string={'paperInvitation': 'CBA'}).json['results']
         assert len(response) == 0
 
-        # Test for paper id query
-        response = test_client.get('/expertise/status/all', query_string={'paperId': openreview_context['job_id']}).json['results']
-        assert len(response) == 1
-        assert response[0]['request']['entityB']['invitation'] == 'ABC.cc/-/Submission'
-
-        response = test_client.get('/expertise/status/all', query_string={'paperId': 'DoesNotExist'}).json['results']
-        assert len(response) == 0
-
-        response = test_client.get('/expertise/status/all', query_string={'paperInvitation': 'CBA'}).json['results']
-        assert len(response) == 0
-
         # Test for combination
         response = test_client.get('/expertise/status/all', query_string={'status': 'Completed', 'memberOf': 'ABC'}).json['results']
         assert len(response) == 2

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -534,6 +534,17 @@ class TestExpertiseService():
         response = test_client.get('/expertise/status/all', query_string={'paperInvitation': 'CBA'}).json['results']
         assert len(response) == 0
 
+        # Test for paper id query
+        response = test_client.get('/expertise/status/all', query_string={'paperId': openreview_context['job_id']}).json['results']
+        assert len(response) == 1
+        assert response[0]['request']['entityB']['invitation'] == 'ABC.cc/-/Submission'
+
+        response = test_client.get('/expertise/status/all', query_string={'paperId': 'DoesNotExist'}).json['results']
+        assert len(response) == 0
+
+        response = test_client.get('/expertise/status/all', query_string={'paperInvitation': 'CBA'}).json['results']
+        assert len(response) == 0
+
         # Test for combination
         response = test_client.get('/expertise/status/all', query_string={'status': 'Completed', 'memberOf': 'ABC'}).json['results']
         assert len(response) == 2


### PR DESCRIPTION
- Resolves #152

This PR fixes some issues in the `/expertise/status` endpoint to now support queries of the form
`GET /expertise/status?memberOf=TMLR/Reviewers&paperId=djtn42lx`