### PR TITLE
Match /status query params with definition

### DIFF
--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -215,17 +215,17 @@ class ExpertiseService(object):
 
         def check_paper_id():
             search_paper_id, paper_id = '', ''
-            if 'paperId' in query_obj.keys():
+            if 'id' in query_obj.keys():
                 paper_id = config.api_request.entityA.get('id', '') or config.api_request.entityB.get('id', '')
-                search_paper_id = query_obj['paperId']
+                search_paper_id = query_obj['id']
 
-            elif 'paperId' in query_obj.get('entityA', {}).keys():
+            elif 'id' in query_obj.get('entityA', {}).keys():
                 paper_id = config.api_request.entityA.get('id', '')
-                search_paper_id = query_obj['entityA']['paperId']
+                search_paper_id = query_obj['entityA']['id']
 
-            elif 'paperId' in query_obj.get('entityB', {}).keys():
+            elif 'id' in query_obj.get('entityB', {}).keys():
                 paper_id = config.api_request.entityB.get('id', '')
-                search_paper_id = query_obj['entityB']['paperId']
+                search_paper_id = query_obj['entityB']['id']
 
             return not search_paper_id or paper_id.lower().startswith(search_paper_id.lower())
 
@@ -243,7 +243,7 @@ class ExpertiseService(object):
         {
             'paperId': value,
             'entityA': {
-                'paperId': value
+                'id': value
             }
         }
         '''

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -199,17 +199,17 @@ class ExpertiseService(object):
         
         def check_invitation():
             search_invitation, inv = '', ''
-            if 'paperInvitation' in query_obj.keys():
+            if 'invitation' in query_obj.keys():
                 inv = config.api_request.entityA.get('invitation', '') or config.api_request.entityB.get('invitation', '')
-                search_invitation = query_obj['paperInvitation']
+                search_invitation = query_obj['invitation']
 
-            elif 'paperInvitation' in query_obj.get('entityA', {}).keys():
+            elif 'invitation' in query_obj.get('entityA', {}).keys():
                 inv = config.api_request.entityA.get('invitation', '')
-                search_invitation = query_obj['entityA']['paperInvitation']
+                search_invitation = query_obj['entityA']['invitation']
 
-            elif 'paperInvitation' in query_obj.get('entityB', {}).keys():
+            elif 'invitation' in query_obj.get('entityB', {}).keys():
                 inv = config.api_request.entityB.get('invitation', '')
-                search_invitation = query_obj['entityB']['paperInvitation']
+                search_invitation = query_obj['entityB']['invitation']
 
             return not search_invitation or inv.lower().startswith(search_invitation.lower())
 

--- a/tests/test_expertise_apiv2.py
+++ b/tests/test_expertise_apiv2.py
@@ -263,23 +263,23 @@ class TestExpertiseV2():
         assert response['description'] == 'Job is complete and the computed scores are ready'
 
         # Test for paper id query
-        response = test_client.get('/expertise/status', query_string={'paperId': target_id}).json['results']
+        response = test_client.get('/expertise/status', query_string={'id': target_id}).json['results']
         assert len(response) == 2
 
         # Test for paper id and member of query
-        response = test_client.get('/expertise/status', query_string={'paperId': target_id, 'memberOf': 'TMLR/Reviewers'}).json['results']
+        response = test_client.get('/expertise/status', query_string={'id': target_id, 'memberOf': 'TMLR/Reviewers'}).json['results']
         assert len(response) == 1
 
-        response = test_client.get('/expertise/status', query_string={'entityB.paperId': target_id, 'memberOf': 'TMLR/Reviewers'}).json['results']
+        response = test_client.get('/expertise/status', query_string={'entityB.id': target_id, 'memberOf': 'TMLR/Reviewers'}).json['results']
         assert len(response) == 1
 
-        response = test_client.get('/expertise/status', query_string={'entityB.paperId': target_id, 'entityB.memberOf': 'TMLR/Reviewers'}).json['results']
+        response = test_client.get('/expertise/status', query_string={'entityB.id': target_id, 'entityB.memberOf': 'TMLR/Reviewers'}).json['results']
         assert len(response) == 0
 
-        response = test_client.get('/expertise/status', query_string={'entityA.paperId': target_id}).json['results']
+        response = test_client.get('/expertise/status', query_string={'entityA.id': target_id}).json['results']
         assert len(response) == 0
 
-        response = test_client.get('/expertise/status', query_string={'paperId': 'DoesNotExist'}).json['results']
+        response = test_client.get('/expertise/status', query_string={'id': 'DoesNotExist'}).json['results']
         assert len(response) == 0
 
         response = test_client.get('/expertise/results', query_string={'jobId': f'{job_id}', 'deleteOnGet': True})

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -526,12 +526,12 @@ class TestExpertiseService():
         assert len(response) == 0
 
         # Test for invitation query
-        response = test_client.get('/expertise/status/all', query_string={'paperInvitation': 'ABC.cc'}).json['results']
+        response = test_client.get('/expertise/status/all', query_string={'invitation': 'ABC.cc'}).json['results']
         assert len(response) == 2
         assert response[0]['request']['entityB']['invitation'] == 'ABC.cc/-/Submission'
         assert response[1]['request']['entityB']['invitation'] == 'ABC.cc/-/Submission'
 
-        response = test_client.get('/expertise/status/all', query_string={'paperInvitation': 'CBA'}).json['results']
+        response = test_client.get('/expertise/status/all', query_string={'invitation': 'CBA'}).json['results']
         assert len(response) == 0
 
         # Test for combination


### PR DESCRIPTION
This PR now has the `/status` endpoint check for `id` (and `entityA/B.id`) and `invitation` (and `entityA/B.invitation`) instead of `paperId` and `paperInvitation` in the query params