### PR TITLE
Remove Redis Cache From Tests

### DIFF
--- a/tests/test_spectermfr.py
+++ b/tests/test_spectermfr.py
@@ -81,7 +81,7 @@ def test_smfr_scores(tmp_path, create_smfr, create_specter):
     publications_path.mkdir()
     submissions_path = tmp_path / 'submissions'
     submissions_path.mkdir()
-    smfrModel.embed_publications(specter_publications_path=publications_path,
+    smfrModel.embed_publications(specter_publications_path=publications_path.joinpath('pub2vec.jsonl'),
                                  mfr_publications_path=None,
                                  skip_specter=config['model_params'].get('skip_specter', False))
     smfrModel.embed_submissions(submissions_path.joinpath('sub2vec.jsonl'),
@@ -90,7 +90,7 @@ def test_smfr_scores(tmp_path, create_smfr, create_specter):
     scores_path = tmp_path / 'scores'
     scores_path.mkdir()
     all_scores = smfrModel.all_scores(
-        specter_publications_path=None,
+        specter_publications_path=publications_path.joinpath('pub2vec.jsonl'),
         mfr_publications_path=None,
         specter_submissions_path=submissions_path.joinpath('sub2vec.jsonl'),
         mfr_submissions_path=None,
@@ -120,7 +120,7 @@ def test_sparse_scores(tmp_path, create_smfr):
     publications_path.mkdir()
     submissions_path = tmp_path / 'submissions'
     submissions_path.mkdir()
-    smfrModel.embed_publications(specter_publications_path=publications_path,
+    smfrModel.embed_publications(specter_publications_path=publications_path.joinpath('pub2vec.jsonl'),
                                  mfr_publications_path=None,
                                  skip_specter=config['model_params'].get('skip_specter', False))
     smfrModel.embed_submissions(submissions_path.joinpath('sub2vec.jsonl'),
@@ -129,7 +129,7 @@ def test_sparse_scores(tmp_path, create_smfr):
     scores_path = tmp_path / 'scores'
     scores_path.mkdir()
     all_scores = smfrModel.all_scores(
-        specter_publications_path=None,
+        specter_publications_path=publications_path.joinpath('pub2vec.jsonl'),
         mfr_publications_path=None,
         specter_submissions_path=submissions_path.joinpath('sub2vec.jsonl'),
         mfr_submissions_path=None,

--- a/tests/test_spectermfr.py
+++ b/tests/test_spectermfr.py
@@ -74,7 +74,6 @@ def test_smfr_scores(tmp_path, create_smfr, create_specter):
         }
     }
 
-    redis_con = redisai.Client(host='localhost', port=6379, db=11)
     specterModel = create_specter(config)
     smfrModel = create_smfr(config)
 
@@ -82,7 +81,8 @@ def test_smfr_scores(tmp_path, create_smfr, create_specter):
     publications_path.mkdir()
     submissions_path = tmp_path / 'submissions'
     submissions_path.mkdir()
-    smfrModel.embed_publications(mfr_publications_path=None,
+    smfrModel.embed_publications(specter_publications_path=publications_path,
+                                 mfr_publications_path=None,
                                  skip_specter=config['model_params'].get('skip_specter', False))
     smfrModel.embed_submissions(submissions_path.joinpath('sub2vec.jsonl'),
             mfr_submissions_path=None, skip_specter=config['model_params'].get('skip_specter', False))
@@ -120,7 +120,8 @@ def test_sparse_scores(tmp_path, create_smfr):
     publications_path.mkdir()
     submissions_path = tmp_path / 'submissions'
     submissions_path.mkdir()
-    smfrModel.embed_publications(mfr_publications_path=None,
+    smfrModel.embed_publications(specter_publications_path=publications_path,
+                                 mfr_publications_path=None,
                                  skip_specter=config['model_params'].get('skip_specter', False))
     smfrModel.embed_submissions(submissions_path.joinpath('sub2vec.jsonl'),
             mfr_submissions_path=None, skip_specter=config['model_params'].get('skip_specter', False))

--- a/tests/test_spectermfr.py
+++ b/tests/test_spectermfr.py
@@ -76,7 +76,6 @@ def test_smfr_scores(tmp_path, create_smfr, create_specter):
 
     redis_con = redisai.Client(host='localhost', port=6379, db=11)
     specterModel = create_specter(config)
-    config['model_params']['use_redis'] = True
     smfrModel = create_smfr(config)
 
     publications_path = tmp_path / 'publications'
@@ -99,16 +98,6 @@ def test_smfr_scores(tmp_path, create_smfr, create_specter):
     )
 
     specterModel.embed_publications(publications_path.joinpath('pub2vec.jsonl'))
-    with open(publications_path.joinpath('pub2vec.jsonl')) as f_in:
-        for line in f_in:
-            paper_data = json.loads(line.rstrip())
-            paper_id = paper_data['paper_id']
-            assert paper_id != 'dsPcInkL'
-            paper_embedding = numpy.array(paper_data['embedding'])
-            paper_emb_redis = redis_con.tensorget(paper_id + "_1234567890", as_numpy_mutable=True)
-            assert numpy.all(paper_emb_redis == paper_embedding)
-    assert not redis_con.exists("dsPcInkL")
-
 
 def test_sparse_scores(tmp_path, create_smfr):
     config = {
@@ -122,7 +111,7 @@ def test_sparse_scores(tmp_path, create_smfr):
             'max_score': False,
             'work_dir': tmp_path,
             'sparse_value': 1,
-            'use_redis': True
+            'use_redis': False
         }
     }
     smfrModel = create_smfr(config)
@@ -152,33 +141,3 @@ def test_sparse_scores(tmp_path, create_smfr):
         )
 
     assert len(all_scores) == 8
-
-
-def test_specter_scores_updated_mdate(tmp_path, create_specter):
-    config = {
-        'name': 'test_specter_mdate',
-        'model_params': {
-            'use_title': False,
-            'use_abstract': True,
-            'use_cuda': False,
-            'batch_size': 1,
-            'average_score': True,
-            'max_score': False,
-            'work_dir': tmp_path,
-            'use_redis': True
-        }
-    }
-
-    redis_con = redisai.Client(host='localhost', port=6379, db=11)
-    specterModel = create_specter(config, archives_path='tests/data/archives_updated')
-    publications_path = tmp_path / 'publications'
-    publications_path.mkdir()
-    specterModel.embed_publications(publications_path.joinpath('pub2vec.jsonl'))
-    with open(publications_path.joinpath('pub2vec.jsonl')) as f_in:
-        for line in f_in:
-            paper_data = json.loads(line.rstrip())
-            paper_id = paper_data['paper_id']
-            paper_embedding = numpy.array(paper_data['embedding'])
-            assert not redis_con.exists(paper_id + "_1234567890")
-            paper_emb_redis = redis_con.tensorget(paper_id + "_2345678901", as_numpy_mutable=True)
-            assert numpy.all(paper_emb_redis == paper_embedding)


### PR DESCRIPTION
This PR removes the Redis cache from the tests as it is no longer being used - we can fully deprecate it in the models when we find another way to cache the embeddings