### PR TITLE
Improvements to Delete Endpoint and Statuses

### DIFF
--- a/expertise/service/celery_tasks.py
+++ b/expertise/service/celery_tasks.py
@@ -77,7 +77,7 @@ def after_expertise_return(self, status, retval, task_id, args, kwargs, einfo):
     bind=True,
     time_limit=3600 * 24
 )
-def run_userpaper(self, config: JobConfig, token: str, logger: logging.Logger):
+def run_userpaper(self, config: JobConfig, token: str, logger: logging.Logger, config_json: dict):
     openreview_client = openreview.Client(
         token=token,
         baseurl=config.baseurl

--- a/expertise/service/celery_tasks.py
+++ b/expertise/service/celery_tasks.py
@@ -59,25 +59,25 @@ def on_failure_expertise(self, exc, task_id, args, kwargs, einfo):
 
 def before_userpaper_start(self, task_id, args, kwargs):
     config, logger = args[0], args[2]
-    if config.status != JobStatus.ERROR:
+    if config.status != JobStatus.ERROR and config.status != JobStatus.REVOKED:
         logger.info(f"New status: {JobStatus.FETCHING_DATA}")
         update_status(args[0], JobStatus.FETCHING_DATA)
 
 def before_expertise_start(self, task_id, args, kwargs):
     config, logger = args[0], args[1]
-    if config.status != JobStatus.ERROR:
+    if config.status != JobStatus.ERROR and config.status != JobStatus.REVOKED:
         logger.info(f"New status: {JobStatus.RUN_EXPERTISE}")
         update_status(args[0], JobStatus.RUN_EXPERTISE)
 
 def after_userpaper_return(self, status, retval, task_id, args, kwargs, einfo):
     config, logger = args[0], args[2]
-    if config.status != JobStatus.ERROR:
+    if config.status != JobStatus.ERROR and config.status != JobStatus.REVOKED:
         logger.info(f"New status: {JobStatus.EXPERTISE_QUEUED}")
         update_status(args[0], JobStatus.EXPERTISE_QUEUED)
 
 def after_expertise_return(self, status, retval, task_id, args, kwargs, einfo):
     config, logger = args[0], args[1]
-    if config.status != JobStatus.ERROR:
+    if config.status != JobStatus.ERROR and config.status != JobStatus.REVOKED:
         logger.info(f"New status: {JobStatus.COMPLETED}")
         update_status(args[0], JobStatus.COMPLETED)
 

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -155,7 +155,7 @@ class ExpertiseService(object):
         # Config has passed validation - add it to the user index
         self.logger.info('just before submitting')
         run_userpaper.apply_async(
-            (config, token, self.logger),
+            (config, token, self.logger, config.to_json()),
             queue='userpaper',
             task_id=job_id
         )

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -399,7 +399,8 @@ class ExpertiseService(object):
         :returns: Filtered config of the job to be deleted
         """
         config = self.redis.load_job(job_id, user_id)
-        
+        descriptions = JobDescription.VALS.value
+
         # Clear directory and Redis entry if not going to be processed anymore
         STALE_STATUSES = [JobStatus.COMPLETED, JobStatus.ERROR]
         if config.status in STALE_STATUSES:
@@ -410,8 +411,9 @@ class ExpertiseService(object):
                 self.logger.info(f"No files found - only removing Redis entry")
             self.redis.remove_job(user_id, job_id)
         else:
+            self.logger.info(f"Revoking {config.job_dir} for {user_id}")
             config.status = JobStatus.REVOKED
-            config.description = JobDescription[JobStatus.REVOKED]
+            config.description = descriptions[JobStatus.REVOKED]
             self.redis.save_job(config)
 
         # Return filtered config

--- a/expertise/service/routes.py
+++ b/expertise/service/routes.py
@@ -213,7 +213,7 @@ def all_jobs():
         flask.current_app.logger.error(str(error_handle))
         return flask.jsonify(format_error(500, 'Internal server error: {}'.format(error_handle))), 500
 
-@BLUEPRINT.route('/expertise/delete', methods=['GET'])
+@BLUEPRINT.route('/expertise/delete', methods=['POST'])
 def delete_job():
     """
     Retrieves the config of a job to be deleted, and removes the job by deleting the job directory.
@@ -234,11 +234,11 @@ def delete_job():
 
     try:
         # Parse query parameters
-        job_id = flask.request.args.get('jobId', None)
+        job_id = flask.request.json.get('jobId', None)
         if job_id is None or len(job_id) == 0:
             raise openreview.OpenReviewException('Bad request: jobId is required')
         result = ExpertiseService(openreview_client, flask.current_app.config, flask.current_app.logger).del_expertise_job(user_id, job_id)
-        flask.current_app.logger.debug('GET returns ' + str(result))
+        flask.current_app.logger.debug('POST returns ' + str(result))
         return flask.jsonify(result), 200
 
     except openreview.OpenReviewException as error_handle:

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -165,8 +165,9 @@ class RedisDatabase(object):
     def save_job(self, job_config):
         job_config.mdate = int(time.time() * 1000)
         self.db.set(f"job:{job_config.job_id}", pickle.dumps(job_config))
-        with open(os.path.join(job_config.job_dir, 'config.json'), 'w+') as f:
-            json.dump(job_config.to_json(), f, ensure_ascii=False, indent=4)
+        if os.path.isdir(job_config.job_dir):
+            with open(os.path.join(job_config.job_dir, 'config.json'), 'w+') as f:
+                json.dump(job_config.to_json(), f, ensure_ascii=False, indent=4)
     
     def load_all_jobs(self, user_id):
         """

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -48,7 +48,7 @@ class JobDescription(dict, Enum):
         JobStatus.EXPERTISE_QUEUED: 'Job has assembled the data and is waiting in queue for the expertise model',
         JobStatus.RUN_EXPERTISE: 'Job is running the selected expertise model to compute scores',
         JobStatus.COMPLETED: 'Job is complete and the computed scores are ready',
-        JobStatus.REVOKED: 'Job is complete and the computed scores are ready'
+        JobStatus.REVOKED: 'Job is revoked and will be cleaned up'
     }
 class APIRequest(object):
     """

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -38,6 +38,7 @@ class JobStatus(str, Enum):
     RUN_EXPERTISE = 'Running Expertise'
     COMPLETED = 'Completed'
     ERROR = 'Error'
+    REVOKED = 'Revoked'
 
 class JobDescription(dict, Enum):
     VALS = {
@@ -47,6 +48,7 @@ class JobDescription(dict, Enum):
         JobStatus.EXPERTISE_QUEUED: 'Job has assembled the data and is waiting in queue for the expertise model',
         JobStatus.RUN_EXPERTISE: 'Job is running the selected expertise model to compute scores',
         JobStatus.COMPLETED: 'Job is complete and the computed scores are ready',
+        JobStatus.REVOKED: 'Job is complete and the computed scores are ready'
     }
 class APIRequest(object):
     """

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -163,7 +163,10 @@ class RedisDatabase(object):
         else:
             self.db = redis.Redis(connection_pool=connection_pool)
     def save_job(self, job_config):
+        job_config.mdate = int(time.time() * 1000)
         self.db.set(f"job:{job_config.job_id}", pickle.dumps(job_config))
+        with open(os.path.join(job_config.job_dir, 'config.json'), 'w+') as f:
+            json.dump(job_config.to_json(), f, ensure_ascii=False, indent=4)
     
     def load_all_jobs(self, user_id):
         """

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -831,7 +831,7 @@ class TestExpertiseService():
 
         openreview_context['job_id'] = job_id
 
-    def test_get_results_and_get_error(self, openreview_context, celery_session_app, celery_session_worker):
+    def test_get_results_and_get_error(self, openreview_client, openreview_context, celery_session_app, celery_session_worker):
         MAX_TIMEOUT = 600 # Timeout after 10 minutes
         assert openreview_context['job_id'] is not None
         test_client = openreview_context['test_client']
@@ -856,7 +856,9 @@ class TestExpertiseService():
         ###assert os.path.isfile(f"{server_config['WORKING_DIR']}/{job_id}/err.log")
 
         # Clean up error job by calling the delete endpoint
-        response = test_client.get('/expertise/delete', query_string={'jobId': f"{openreview_context['job_id']}"}).json
+        response = test_client.post('/expertise/delete', data=json.dumps({'jobId': f"{openreview_context['job_id']}"}),
+            content_type='application/json',
+            headers=openreview_client.headers).json
         assert response['name'] == 'test_run'
         assert response['cdate'] <= response['mdate']
         assert not os.path.isdir(f"./tests/jobs/{openreview_context['job_id']}")
@@ -894,7 +896,7 @@ class TestExpertiseService():
 
         openreview_context['job_id'] = job_id
 
-    def test_get_results_and_get_no_submission_error(self, openreview_context, celery_session_app, celery_session_worker):
+    def test_get_results_and_get_no_submission_error(self, openreview_client, openreview_context, celery_session_app, celery_session_worker):
         MAX_TIMEOUT = 600 # Timeout after 10 minutes
         assert openreview_context['job_id'] is not None
         test_client = openreview_context['test_client']
@@ -919,7 +921,10 @@ class TestExpertiseService():
         ###assert os.path.isfile(f"{server_config['WORKING_DIR']}/{job_id}/err.log")
 
         # Clean up error job by calling the delete endpoint
-        response = test_client.get('/expertise/delete', query_string={'jobId': f"{openreview_context['job_id']}"}).json
+        response = test_client.post('/expertise/delete', data=json.dumps({'jobId': f"{openreview_context['job_id']}"}),
+            content_type='application/json',
+            headers=openreview_client.headers
+        ).json
         assert response['name'] == 'test_run'
         assert response['cdate'] <= response['mdate']
         assert not os.path.isdir(f"./tests/jobs/{openreview_context['job_id']}")


### PR DESCRIPTION
Resolves
- #166 
- #156 

This PR contains the following changes:
- Switches the `/delete` endpoint to POST
- Adds a new status `Revoked` to the JobConfig
- Fixes a bug where jobs that were waiting to have their scores computed were displayed as running, now they are shown as queued for expertise
- Adds the JobConfig as a dict to the Celery task arguments so the job information is visible when querying the queue by the Celery CLI
- Changes the logic of the `/delete` endpoint:
    - If called on a running job (any job whose status is not error or completed), sets the status to revoked, the job maintains the revoked status and gets cleaned up after making a final check in the `expertise` Celery task
    - If called on a non-running jobs (either error or completed), cleans the files on disk and removes the job from Redis
- Changes the high load test (which queues 5 jobs) to revoke the last job and checks that it was cleaned up correctly