### PR TITLE
Use PyTorch for New Model Embeddings

### DIFF
--- a/expertise/execute_expertise.py
+++ b/expertise/execute_expertise.py
@@ -113,21 +113,21 @@ def execute_expertise(config):
         )
         ens_predictor.set_archives_dataset(archives_dataset)
         ens_predictor.set_submissions_dataset(submissions_dataset)
-        specter_publication_path = Path(config['model_params']['publications_path']).joinpath('pub2vec_specter.jsonl')
-        scincl_publication_path = Path(config['model_params']['publications_path']).joinpath('pub2vec_scincl.jsonl')
+        specter_publication_path = Path(config['model_params']['publications_path']).joinpath('pub2vec_specter.pt')
+        scincl_publication_path = Path(config['model_params']['publications_path']).joinpath('pub2vec_scincl.pt')
         ens_predictor.embed_publications(
             specter_publications_path=specter_publication_path,
             scincl_publications_path=scincl_publication_path
         )
         ens_predictor.embed_submissions(
-            specter_submissions_path=Path(config['model_params']['submissions_path']).joinpath('sub2vec_specter.jsonl'),
-            scincl_submissions_path=Path(config['model_params']['submissions_path']).joinpath('sub2vec_scincl.jsonl')
+            specter_submissions_path=Path(config['model_params']['submissions_path']).joinpath('sub2vec_specter.pt'),
+            scincl_submissions_path=Path(config['model_params']['submissions_path']).joinpath('sub2vec_scincl.pt')
         )
         ens_predictor.all_scores(
             specter_publications_path=specter_publication_path,
             scincl_publications_path=scincl_publication_path,
-            specter_submissions_path=Path(config['model_params']['submissions_path']).joinpath('sub2vec_specter.jsonl'),
-            scincl_submissions_path=Path(config['model_params']['submissions_path']).joinpath('sub2vec_scincl.jsonl'),
+            specter_submissions_path=Path(config['model_params']['submissions_path']).joinpath('sub2vec_specter.pt'),
+            scincl_submissions_path=Path(config['model_params']['submissions_path']).joinpath('sub2vec_scincl.pt'),
             scores_path=Path(config['model_params']['scores_path']).joinpath(config['name'] + '.csv')
         )
 
@@ -150,16 +150,16 @@ def execute_expertise(config):
         )
         scincl_predictor.set_archives_dataset(archives_dataset)
         scincl_predictor.set_submissions_dataset(submissions_dataset)
-        scincl_publication_path = Path(config['model_params']['publications_path']).joinpath('pub2vec.jsonl')
+        scincl_publication_path = Path(config['model_params']['publications_path']).joinpath('pub2vec.pt')
         scincl_predictor.embed_publications(
             scincl_publication_path
         )
         scincl_predictor.embed_submissions(
-            Path(config['model_params']['submissions_path']).joinpath('sub2vec.jsonl')
+            Path(config['model_params']['submissions_path']).joinpath('sub2vec.pt')
         )
         scincl_predictor.all_scores(
             scincl_publication_path,
-            Path(config['model_params']['submissions_path']).joinpath('sub2vec.jsonl'),
+            Path(config['model_params']['submissions_path']).joinpath('sub2vec.pt'),
             Path(config['model_params']['scores_path']).joinpath(config['name'] + '.csv'),
             p2p_path=Path(config['model_params']['scores_path']).joinpath(config['name'] + '_p2p' + '.json')
         )
@@ -183,16 +183,16 @@ def execute_expertise(config):
         )
         spec2_predictor.set_archives_dataset(archives_dataset)
         spec2_predictor.set_submissions_dataset(submissions_dataset)
-        specter_publication_path = Path(config['model_params']['publications_path']).joinpath('pub2vec.jsonl')
+        specter_publication_path = Path(config['model_params']['publications_path']).joinpath('pub2vec.pt')
         spec2_predictor.embed_publications(
             specter_publication_path
         )
         spec2_predictor.embed_submissions(
-            Path(config['model_params']['submissions_path']).joinpath('sub2vec.jsonl')
+            Path(config['model_params']['submissions_path']).joinpath('sub2vec.pt')
         )
         spec2_predictor.all_scores(
             specter_publication_path,
-            Path(config['model_params']['submissions_path']).joinpath('sub2vec.jsonl'),
+            Path(config['model_params']['submissions_path']).joinpath('sub2vec.pt'),
             Path(config['model_params']['scores_path']).joinpath(config['name'] + '.csv'),
             p2p_path=Path(config['model_params']['scores_path']).joinpath(config['name'] + '_p2p' + '.json')
         )

--- a/expertise/models/specter2_scincl/predictor.py
+++ b/expertise/models/specter2_scincl/predictor.py
@@ -26,3 +26,26 @@ class Predictor:
             if not batch:
                 break
             yield batch
+
+    def _batch_predict(self, batch_data):
+        jsonl_out = []
+        text_batch = [d[1]['title'] + self.tokenizer.sep_token + (d[1].get('abstract') or '') for d in batch_data]
+        # preprocess the input
+        inputs = self.tokenizer(text_batch, padding=True, truncation=True,
+                                        return_tensors="pt", return_token_type_ids=False, max_length=512)
+        inputs = inputs.to(self.cuda_device)
+        with torch.no_grad():
+            output = self.model(**inputs)
+        # take the first token in the batch as the embedding
+        embeddings = output.last_hidden_state[:, 0, :]
+
+        for paper, embedding in zip(batch_data, embeddings):
+            paper = paper[1]
+            jsonl_out.append(json.dumps({'paper_id': paper['paper_id'], 'embedding': embedding.detach().cpu().numpy().tolist()}) + '\n')
+
+        # clean up batch data
+        del embeddings
+        del output
+        del inputs
+        torch.cuda.empty_cache()
+        return jsonl_out

--- a/expertise/models/specter2_scincl/predictor.py
+++ b/expertise/models/specter2_scincl/predictor.py
@@ -1,5 +1,6 @@
 from tqdm import tqdm
 import itertools
+import torch, json
 class Predictor:
     def _sparse_scores_helper(self, all_scores, id_index):
         counter = 0
@@ -41,7 +42,7 @@ class Predictor:
 
         for paper, embedding in zip(batch_data, embeddings):
             paper = paper[1]
-            jsonl_out.append(json.dumps({'paper_id': paper['paper_id'], 'embedding': embedding.detach().cpu().numpy().tolist()}) + '\n')
+            jsonl_out.append(json.dumps({'paper_id': paper['paper_id'], 'embedding': embedding}) + '\n')
 
         # clean up batch data
         del embeddings

--- a/expertise/models/specter2_scincl/predictor.py
+++ b/expertise/models/specter2_scincl/predictor.py
@@ -1,4 +1,5 @@
 from tqdm import tqdm
+import itertools
 class Predictor:
     def _sparse_scores_helper(self, all_scores, id_index):
         counter = 0
@@ -17,3 +18,11 @@ class Predictor:
                 current_id = (note_id, profile_id)[id_index]
             counter += 1
         return all_scores
+
+    def _fetch_batches(self, dict_data, batch_size):
+        iterator = iter(dict_data.items())
+        for _ in itertools.count():
+            batch = list(itertools.islice(iterator, batch_size))
+            if not batch:
+                break
+            yield batch

--- a/expertise/models/specter2_scincl/predictor.py
+++ b/expertise/models/specter2_scincl/predictor.py
@@ -1,4 +1,5 @@
 from tqdm import tqdm
+import openreview
 import itertools
 import torch, json
 class Predictor:
@@ -79,6 +80,8 @@ class Predictor:
                 paper_emb = paper_data['embedding']
             id_list.append(paper_id)
             emb_list.append(paper_emb)
+        if len(emb_list) == 0:
+            raise openreview.OpenReviewException('No embeddings found. Please check that you have at least 1 submission submitted and that you have run the Post Submission stage.')
         emb_tensor = torch.stack(emb_list)
         emb_tensor = emb_tensor / (emb_tensor.norm(dim=1, keepdim=True) + 0.000000000001)
         print(len(bad_id_set))

--- a/expertise/models/specter2_scincl/predictor.py
+++ b/expertise/models/specter2_scincl/predictor.py
@@ -42,7 +42,7 @@ class Predictor:
 
         for paper, embedding in zip(batch_data, embeddings):
             paper = paper[1]
-            jsonl_out.append(json.dumps({'paper_id': paper['paper_id'], 'embedding': embedding}) + '\n')
+            jsonl_out.append({'paper_id': paper['paper_id'], 'embedding': embedding})
 
         # clean up batch data
         del embeddings
@@ -61,12 +61,13 @@ class Predictor:
 
         torch.save(emb_jsonl, embedding_path)
 
-    def _load_emb_file(emb_file, cuda_device):
+    def _load_emb_file(emb_path, cuda_device):
+        loaded_embeddings = torch.load(emb_path)
         paper_emb_size_default = 768
         id_list = []
         emb_list = []
         bad_id_set = set()
-        for line in emb_file:
+        for line in loaded_embeddings:
             paper_data = line
             paper_id = paper_data['paper_id']
             paper_emb_size = len(paper_data['embedding'])

--- a/expertise/models/specter2_scincl/predictor.py
+++ b/expertise/models/specter2_scincl/predictor.py
@@ -60,3 +60,25 @@ class Predictor:
             emb_jsonl.extend(self._batch_predict(batch_data))
 
         torch.save(emb_jsonl, embedding_path)
+
+    def _load_emb_file(emb_file, cuda_device):
+        paper_emb_size_default = 768
+        id_list = []
+        emb_list = []
+        bad_id_set = set()
+        for line in emb_file:
+            paper_data = line
+            paper_id = paper_data['paper_id']
+            paper_emb_size = len(paper_data['embedding'])
+            assert paper_emb_size == 0 or paper_emb_size == paper_emb_size_default
+            if paper_emb_size == 0:
+                paper_emb = [0] * paper_emb_size_default
+                bad_id_set.add(paper_id)
+            else:
+                paper_emb = paper_data['embedding']
+            id_list.append(paper_id)
+            emb_list.append(paper_emb)
+        emb_tensor = torch.stack(emb_list)
+        emb_tensor = emb_tensor / (emb_tensor.norm(dim=1, keepdim=True) + 0.000000000001)
+        print(len(bad_id_set))
+        return emb_tensor, id_list, bad_id_set

--- a/expertise/models/specter2_scincl/predictor.py
+++ b/expertise/models/specter2_scincl/predictor.py
@@ -50,3 +50,13 @@ class Predictor:
         del inputs
         torch.cuda.empty_cache()
         return jsonl_out
+
+    def _create_embeddings(self, metadata_file, embedding_path):
+        with open(metadata_file, 'r') as f:
+            paper_data = json.load(f)
+
+        emb_jsonl = []
+        for batch_data in tqdm(self._fetch_batches(paper_data, self.batch_size), desc='Embedding Subs', total=int(len(paper_data.keys())/self.batch_size), unit="batches"):
+            emb_jsonl.extend(self._batch_predict(batch_data))
+
+        torch.save(emb_jsonl, embedding_path)

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -156,7 +156,7 @@ class SciNCLPredictor(Predictor):
         paper_num_test = len(test_id_list)
 
         print('Computing all scores...')
-        p2p_aff = torch.empty((paper_num_test, paper_num_train), device=torch.device('cpu'))
+        p2p_aff = torch.empty((paper_num_test, paper_num_train), device=self.cuda_device)
         for i in range(paper_num_test):
             p2p_aff[i, :] = torch.sum(paper_emb_test[i, :].unsqueeze(dim=0) * paper_emb_train, dim=1)
 

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -142,31 +142,9 @@ class SciNCLPredictor(Predictor):
         self._create_embeddings(metadata_file, publications_path)
 
     def all_scores(self, publications_path=None, submissions_path=None, scores_path=None, p2p_path=None):
-        def load_emb_file(emb_file):
-            paper_emb_size_default = 768
-            id_list = []
-            emb_list = []
-            bad_id_set = set()
-            for line in emb_file:
-                paper_data = json.loads(line.rstrip())
-                paper_id = paper_data['paper_id']
-                paper_emb_size = len(paper_data['embedding'])
-                assert paper_emb_size == 0 or paper_emb_size == paper_emb_size_default
-                if paper_emb_size == 0:
-                    paper_emb = [0] * paper_emb_size_default
-                    bad_id_set.add(paper_id)
-                else:
-                    paper_emb = paper_data['embedding']
-                id_list.append(paper_id)
-                emb_list.append(paper_emb)
-            emb_tensor = torch.tensor(emb_list, device=torch.device('cpu'))
-            emb_tensor = emb_tensor / (emb_tensor.norm(dim=1, keepdim=True) + 0.000000000001)
-            print(len(bad_id_set))
-            return emb_tensor, id_list, bad_id_set
-
         print('Loading cached publications...')
         with open(publications_path) as f_in:
-            paper_emb_train, train_id_list, train_bad_id_set = load_emb_file(f_in)
+            paper_emb_train, train_id_list, train_bad_id_set = self._load_emb_file(f_in)
         paper_num_train = len(train_id_list)
 
         paper_id2train_idx = {}
@@ -175,7 +153,7 @@ class SciNCLPredictor(Predictor):
 
         with open(submissions_path) as f_in:
             print('Loading cached submissions...')
-            paper_emb_test, test_id_list, test_bad_id_set = load_emb_file(f_in)
+            paper_emb_test, test_id_list, test_bad_id_set = self._load_emb_file(f_in)
             paper_num_test = len(test_id_list)
 
         print('Computing all scores...')

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -130,15 +130,7 @@ class SciNCLPredictor(Predictor):
         metadata_file = os.path.join(self.work_dir, "scincl_submission_paper_data.json")
         ids_file = os.path.join(self.work_dir, "scincl_submission_paper_ids.txt")
 
-        with open(metadata_file, 'r') as f:
-            paper_data = json.load(f)
-
-        sub_jsonl = []
-        for batch_data in tqdm(self._fetch_batches(paper_data, self.batch_size), desc='Embedding Subs', total=int(len(paper_data.keys())/self.batch_size), unit="batches"):
-            sub_jsonl.extend(self._batch_predict(batch_data))
-
-        with open(submissions_path, 'w') as f:
-            f.writelines(sub_jsonl)
+        self._create_embeddings(metadata_file, submissions_path)
 
     def embed_publications(self, publications_path=None):
         if not self.use_redis:
@@ -147,15 +139,7 @@ class SciNCLPredictor(Predictor):
         metadata_file = os.path.join(self.work_dir, "scincl_reviewer_paper_data.json")
         ids_file = os.path.join(self.work_dir, "scincl_reviewer_paper_ids.txt")
 
-        with open(metadata_file, 'r') as f:
-            paper_data = json.load(f)
-
-        pub_jsonl = []
-        for batch_data in tqdm(self._fetch_batches(paper_data, self.batch_size), desc='Embedding Pubs', total=int(len(paper_data.keys())/self.batch_size), unit="batches"):
-            pub_jsonl.extend(self._batch_predict(batch_data))
-
-        with open(publications_path, 'w') as f:
-            f.writelines(pub_jsonl)
+        self._create_embeddings(metadata_file, publications_path)
 
     def all_scores(self, publications_path=None, submissions_path=None, scores_path=None, p2p_path=None):
         def load_emb_file(emb_file):

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -69,28 +69,6 @@ class SciNCLPredictor(Predictor):
         self.model.to(self.cuda_device)
         self.model.eval()
 
-    def _batch_predict(self, batch_data):
-        jsonl_out = []
-        text_batch = [d[1]['title'] + self.tokenizer.sep_token + (d[1].get('abstract') or '') for d in batch_data]
-        # preprocess the input
-        inputs = self.tokenizer(text_batch, padding=True, truncation=True, return_tensors="pt", max_length=512)
-        inputs = inputs.to(self.cuda_device)
-        with torch.no_grad():
-            output = self.model(**inputs)
-        # take the first token in the batch as the embedding
-        embeddings = output.last_hidden_state[:, 0, :]
-
-        for paper, embedding in zip(batch_data, embeddings):
-            paper = paper[1]
-            jsonl_out.append(json.dumps({'paper_id': paper['paper_id'], 'embedding': embedding.detach().cpu().numpy().tolist()}) + '\n')
-
-        # clean up batch data
-        del embeddings
-        del output
-        del inputs
-        torch.cuda.empty_cache()
-        return jsonl_out
-
     def set_archives_dataset(self, archives_dataset):
         self.pub_note_id_to_author_ids = defaultdict(list)
         self.pub_author_ids_to_note_id = defaultdict(list)

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -143,18 +143,17 @@ class SciNCLPredictor(Predictor):
 
     def all_scores(self, publications_path=None, submissions_path=None, scores_path=None, p2p_path=None):
         print('Loading cached publications...')
-        with open(publications_path) as f_in:
-            paper_emb_train, train_id_list, train_bad_id_set = self._load_emb_file(f_in)
+        paper_emb_train, train_id_list, train_bad_id_set = Predictor._load_emb_file(publications_path, self.cuda_device)
         paper_num_train = len(train_id_list)
 
         paper_id2train_idx = {}
         for idx, paper_id in enumerate(train_id_list):
             paper_id2train_idx[paper_id] = idx
 
-        with open(submissions_path) as f_in:
-            print('Loading cached submissions...')
-            paper_emb_test, test_id_list, test_bad_id_set = self._load_emb_file(f_in)
-            paper_num_test = len(test_id_list)
+        
+        print('Loading cached submissions...')
+        paper_emb_test, test_id_list, test_bad_id_set = Predictor._load_emb_file(submissions_path, self.cuda_device)
+        paper_num_test = len(test_id_list)
 
         print('Computing all scores...')
         p2p_aff = torch.empty((paper_num_test, paper_num_train), device=torch.device('cpu'))

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -69,14 +69,6 @@ class SciNCLPredictor(Predictor):
         self.model.to(self.cuda_device)
         self.model.eval()
 
-    def _fetch_batches(self, dict_data, batch_size):
-        iterator = iter(dict_data.items())
-        for _ in itertools.count():
-            batch = list(itertools.islice(iterator, batch_size))
-            if not batch:
-                break
-            yield batch
-
     def _batch_predict(self, batch_data):
         jsonl_out = []
         text_batch = [d[1]['title'] + self.tokenizer.sep_token + (d[1].get('abstract') or '') for d in batch_data]

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -72,13 +72,6 @@ class Specter2Predictor(Predictor):
         self.model.to(self.cuda_device)
         self.model.eval()
 
-    def _fetch_batches(self, dict_data, batch_size):
-        iterator = iter(dict_data.items())
-        for _ in itertools.count():
-            batch = list(itertools.islice(iterator, batch_size))
-            if not batch:
-                break
-            yield batch
 
     def _batch_predict(self, batch_data):
         jsonl_out = []

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -145,31 +145,9 @@ class Specter2Predictor(Predictor):
         self._create_embeddings(metadata_file, publications_path)
 
     def all_scores(self, publications_path=None, submissions_path=None, scores_path=None, p2p_path=None):
-        def load_emb_file(emb_file):
-            paper_emb_size_default = 768
-            id_list = []
-            emb_list = []
-            bad_id_set = set()
-            for line in emb_file:
-                paper_data = json.loads(line.rstrip())
-                paper_id = paper_data['paper_id']
-                paper_emb_size = len(paper_data['embedding'])
-                assert paper_emb_size == 0 or paper_emb_size == paper_emb_size_default
-                if paper_emb_size == 0:
-                    paper_emb = [0] * paper_emb_size_default
-                    bad_id_set.add(paper_id)
-                else:
-                    paper_emb = paper_data['embedding']
-                id_list.append(paper_id)
-                emb_list.append(paper_emb)
-            emb_tensor = torch.tensor(emb_list, device=torch.device('cpu'))
-            emb_tensor = emb_tensor / (emb_tensor.norm(dim=1, keepdim=True) + 0.000000000001)
-            print(len(bad_id_set))
-            return emb_tensor, id_list, bad_id_set
-
         print('Loading cached publications...')
         with open(publications_path) as f_in:
-            paper_emb_train, train_id_list, train_bad_id_set = load_emb_file(f_in)
+            paper_emb_train, train_id_list, train_bad_id_set = self._load_emb_file(f_in)
         paper_num_train = len(train_id_list)
 
         paper_id2train_idx = {}
@@ -178,7 +156,7 @@ class Specter2Predictor(Predictor):
 
         with open(submissions_path) as f_in:
             print('Loading cached submissions...')
-            paper_emb_test, test_id_list, test_bad_id_set = load_emb_file(f_in)
+            paper_emb_test, test_id_list, test_bad_id_set = self._load_emb_file(f_in)
             paper_num_test = len(test_id_list)
 
         print('Computing all scores...')

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -133,15 +133,7 @@ class Specter2Predictor(Predictor):
         metadata_file = os.path.join(self.work_dir, "specter_submission_paper_data.json")
         ids_file = os.path.join(self.work_dir, "specter_submission_paper_ids.txt")
 
-        with open(metadata_file, 'r') as f:
-            paper_data = json.load(f)
-
-        sub_jsonl = []
-        for batch_data in tqdm(self._fetch_batches(paper_data, self.batch_size), desc='Embedding Subs', total=int(len(paper_data.keys())/self.batch_size), unit="batches"):
-            sub_jsonl.extend(self._batch_predict(batch_data))
-
-        with open(submissions_path, 'w') as f:
-            f.writelines(sub_jsonl)
+        self._create_embeddings(metadata_file, submissions_path)
 
     def embed_publications(self, publications_path=None):
         if not self.use_redis:
@@ -150,15 +142,7 @@ class Specter2Predictor(Predictor):
         metadata_file = os.path.join(self.work_dir, "specter_reviewer_paper_data.json")
         ids_file = os.path.join(self.work_dir, "specter_reviewer_paper_ids.txt")
 
-        with open(metadata_file, 'r') as f:
-            paper_data = json.load(f)
-
-        pub_jsonl = []
-        for batch_data in tqdm(self._fetch_batches(paper_data, self.batch_size), desc='Embedding Pubs', total=int(len(paper_data.keys())/self.batch_size), unit="batches"):
-            pub_jsonl.extend(self._batch_predict(batch_data))
-
-        with open(publications_path, 'w') as f:
-            f.writelines(pub_jsonl)
+        self._create_embeddings(metadata_file, publications_path)
 
     def all_scores(self, publications_path=None, submissions_path=None, scores_path=None, p2p_path=None):
         def load_emb_file(emb_file):

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -72,30 +72,6 @@ class Specter2Predictor(Predictor):
         self.model.to(self.cuda_device)
         self.model.eval()
 
-
-    def _batch_predict(self, batch_data):
-        jsonl_out = []
-        text_batch = [d[1]['title'] + self.tokenizer.sep_token + (d[1].get('abstract') or '') for d in batch_data]
-        # preprocess the input
-        inputs = self.tokenizer(text_batch, padding=True, truncation=True,
-                                        return_tensors="pt", return_token_type_ids=False, max_length=512)
-        inputs = inputs.to(self.cuda_device)
-        with torch.no_grad():
-            output = self.model(**inputs)
-        # take the first token in the batch as the embedding
-        embeddings = output.last_hidden_state[:, 0, :]
-
-        for paper, embedding in zip(batch_data, embeddings):
-            paper = paper[1]
-            jsonl_out.append(json.dumps({'paper_id': paper['paper_id'], 'embedding': embedding.detach().cpu().numpy().tolist()}) + '\n')
-
-        # clean up batch data
-        del embeddings
-        del output
-        del inputs
-        torch.cuda.empty_cache()
-        return jsonl_out
-
     def set_archives_dataset(self, archives_dataset):
         self.pub_note_id_to_author_ids = defaultdict(list)
         self.pub_author_ids_to_note_id = defaultdict(list)

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -146,18 +146,16 @@ class Specter2Predictor(Predictor):
 
     def all_scores(self, publications_path=None, submissions_path=None, scores_path=None, p2p_path=None):
         print('Loading cached publications...')
-        with open(publications_path) as f_in:
-            paper_emb_train, train_id_list, train_bad_id_set = self._load_emb_file(f_in)
+        paper_emb_train, train_id_list, train_bad_id_set = Predictor._load_emb_file(publications_path, self.cuda_device)
         paper_num_train = len(train_id_list)
 
         paper_id2train_idx = {}
         for idx, paper_id in enumerate(train_id_list):
             paper_id2train_idx[paper_id] = idx
 
-        with open(submissions_path) as f_in:
-            print('Loading cached submissions...')
-            paper_emb_test, test_id_list, test_bad_id_set = self._load_emb_file(f_in)
-            paper_num_test = len(test_id_list)
+        print('Loading cached submissions...')
+        paper_emb_test, test_id_list, test_bad_id_set = Predictor._load_emb_file(submissions_path, self.cuda_device)
+        paper_num_test = len(test_id_list)
 
         print('Computing all scores...')
         p2p_aff = torch.empty((paper_num_test, paper_num_train), device=torch.device('cpu'))

--- a/tests/test_expertise_apiv2.py
+++ b/tests/test_expertise_apiv2.py
@@ -525,7 +525,7 @@ class TestExpertiseV2():
 
         assert response['status'] == 'Error'
         assert response['name'] == 'test_run'
-        assert response['description'] == 'Dimension out of range (expected to be in range of [-1, 0], but got 1). Please check that you have at least 1 submission submitted and that you have run the Post Submission stage.'
+        assert response['description'] == 'No embeddings found. Please check that you have at least 1 submission submitted and that you have run the Post Submission stage.'
 
         response = test_client.post(
             '/expertise',

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -54,21 +54,21 @@ def test_specncl_scores(tmp_path, create_specncl):
     submissions_path = tmp_path / 'submissions'
     submissions_path.mkdir()
     specnclModel.embed_publications(
-        specter_publications_path=publications_path.joinpath('pub2vec_specter.jsonl'),
-        scincl_publications_path=publications_path.joinpath('pub2vec_scincl.jsonl')
+        specter_publications_path=publications_path.joinpath('pub2vec_specter.pt'),
+        scincl_publications_path=publications_path.joinpath('pub2vec_scincl.pt')
     )
     specnclModel.embed_submissions(
-        specter_submissions_path=submissions_path.joinpath('sub2vec_specter.jsonl'),
-        scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.jsonl'),
+        specter_submissions_path=submissions_path.joinpath('sub2vec_specter.pt'),
+        scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.pt'),
     )
 
     scores_path = tmp_path / 'scores'
     scores_path.mkdir()
     all_scores = specnclModel.all_scores(
-        specter_publications_path=publications_path.joinpath('pub2vec_specter.jsonl'),
-        scincl_publications_path=publications_path.joinpath('pub2vec_scincl.jsonl'),
-        specter_submissions_path=submissions_path.joinpath('sub2vec_specter.jsonl'),
-        scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.jsonl'),
+        specter_publications_path=publications_path.joinpath('pub2vec_specter.pt'),
+        scincl_publications_path=publications_path.joinpath('pub2vec_scincl.pt'),
+        specter_submissions_path=submissions_path.joinpath('sub2vec_specter.pt'),
+        scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.pt'),
         scores_path=scores_path.joinpath(config['name'] + '.csv')
     )
 
@@ -95,21 +95,21 @@ def test_sparse_scores(tmp_path, create_specncl):
     submissions_path = tmp_path / 'submissions'
     submissions_path.mkdir()
     specnclModel.embed_publications(
-        specter_publications_path=publications_path.joinpath('pub2vec_specter.jsonl'),
-        scincl_publications_path=publications_path.joinpath('pub2vec_scincl.jsonl')
+        specter_publications_path=publications_path.joinpath('pub2vec_specter.pt'),
+        scincl_publications_path=publications_path.joinpath('pub2vec_scincl.pt')
     )
     specnclModel.embed_submissions(
-        specter_submissions_path=submissions_path.joinpath('sub2vec_specter.jsonl'),
-        scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.jsonl'),
+        specter_submissions_path=submissions_path.joinpath('sub2vec_specter.pt'),
+        scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.pt'),
     )
 
     scores_path = tmp_path / 'scores'
     scores_path.mkdir()
     all_scores = specnclModel.all_scores(
-        specter_publications_path=publications_path.joinpath('pub2vec_specter.jsonl'),
-        scincl_publications_path=publications_path.joinpath('pub2vec_scincl.jsonl'),
-        specter_submissions_path=submissions_path.joinpath('sub2vec_specter.jsonl'),
-        scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.jsonl'),
+        specter_publications_path=publications_path.joinpath('pub2vec_specter.pt'),
+        scincl_publications_path=publications_path.joinpath('pub2vec_scincl.pt'),
+        specter_submissions_path=submissions_path.joinpath('sub2vec_specter.pt'),
+        scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.pt'),
         scores_path=scores_path.joinpath(config['name'] + '.csv')
     )
 


### PR DESCRIPTION
This PR moves more shared functions into the Predictor class, avoids moving the embeddings from GPU to CPU each batch (speeds up each iteration), uses PyTorch's `.save()` and `.load()` to store embeddings more efficiently (takes up less disk)