### PR TITLE
Fix: Not Getting All Publications in Group Scoring

### DIFF
--- a/tests/test_create_conference.py
+++ b/tests/test_create_conference.py
@@ -429,7 +429,7 @@ class TestConference():
             for profile_json in data['profiles']:
                 authorid = profile_json['id']
                 if authorid not in tmlr_editors:
-                    for pub_json in profile_json['publications']:
+                    for idx, pub_json in enumerate(profile_json['publications']):
                         content = pub_json['content']
                         content['authorids'] = [authorid]
                         cdate = pub_json.get('cdate')
@@ -438,15 +438,31 @@ class TestConference():
                         existing_titles = [pub.content.get('title') for pub in existing_pubs]
 
                         if content.get('title') not in existing_titles:
-                            note = openreview.Note(
-                                invitation = api_invitation,
-                                readers = ['everyone'],
-                                writers = ['~SomeTest_User1'],
-                                signatures = ['~SomeTest_User1'],
-                                content = content,
-                                cdate = cdate
-                            )
-                            note = client.post_note(note)
+                            if idx % 2 == 0:
+                                note = openreview.Note(
+                                    invitation = api_invitation,
+                                    readers = ['everyone'],
+                                    writers = ['~SomeTest_User1'],
+                                    signatures = ['~SomeTest_User1'],
+                                    content = content,
+                                    cdate = cdate
+                                )
+                                note = client.post_note(note)
+                            else:
+                                edit = openreview_client.post_note_edit(
+                                    invitation='openreview.net/Archive/-/Direct_Upload',
+                                    signatures = ['~SomeTest_User1'],
+                                    note = openreview.api.Note(
+                                        pdate = cdate,
+                                        content = {
+                                            'title': { 'value': content['title'] },
+                                            'abstract': { 'value': content['abstract'] },
+                                            'authors': { 'value': content['authorids'] },
+                                            'authorids': { 'value': content['authorids'] },
+                                            'venue': { 'value': 'Other Venue 2024 Main' }
+                                        },
+                                        license = 'CC BY-SA 4.0'
+                                ))
 
         with open('tests/data/fakeData.json') as json_file:
             data = json.load(json_file)

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -1420,7 +1420,7 @@ class TestExpertiseService():
         # Searches for journal results from the given job_id assuming the job has completed
         response = test_client.get('/expertise/results', query_string={'jobId': f"{openreview_context['job_id']}"})
         metadata = response.json['metadata']
-        assert metadata['submission_count'] == 9
+        assert metadata['submission_count'] == 10
         response = response.json['results']
         for item in response:
             match_id, submitter_id, score = item['match_member'], item['submission_member'], float(item['score'])


### PR DESCRIPTION
The PR fixes an issue where only API1 notes counted in the `alternate_match_group`'s expertise.

These publications are now fetched using the same function as the publications of the `match_group`. The notes are casted to API1 notes for compatibility with the existing code. The tests are modified to split archive uploads between API1 and API2.

Minor change to use `pdate` instead of `cdate` when it is present when doing filtering according to the dataset params