### PR TITLE
Queue: Cleanup resources at the end of each job

### DIFF
--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -3,6 +3,8 @@ import shutil
 import time
 import os
 import json
+import torch
+import gc
 from csv import reader
 import openreview
 from openreview import OpenReviewException
@@ -219,6 +221,10 @@ class ExpertiseService(object):
             self.update_status(config, JobStatus.RUN_EXPERTISE)
             execute_expertise(config=config.to_json())
             self.update_status(config, JobStatus.COMPLETED)
+
+            # Explicitly cleanup resources
+            torch.cuda.empty_cache()
+            gc.collect()
         except Exception as e:
             self.update_status(config, JobStatus.ERROR, str(e))
             # Re raise exception so that it appears in the queue


### PR DESCRIPTION
This PR addresses the issue of processes holding on to GPU memory causing jobs to run out of memory after some time.

This PR explicitly calls the garbage collector and frees the CUDA cache. This does not free **all** of the memory, the process still holds on to some GPU memory for its context, which amounts to 100-200MB per process