### PR TITLE
Queue: Isolate Models in Processes

### DIFF
--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -241,9 +241,6 @@ class ExpertiseService(object):
             process.start()
             process.join()
 
-            if process.exitcode != 0:
-                raise Exception(f"execute_expertise process exit code={process.exitcode}")
-
             # Update job status
             self.update_status(config, JobStatus.COMPLETED)
 

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -69,7 +69,8 @@ class ExpertiseService(object):
         self.optional_fields = ['model', 'model_params', 'exclusion_inv', 'token', 'baseurl', 'baseurl_v2', 'paper_invitation', 'paper_id']
         self.path_fields = ['work_dir', 'scores_path', 'publications_path', 'submissions_path']
 
-        multiprocessing.set_start_method('spawn')
+        if multiprocessing.get_start_method(allow_none=True) != 'spawn':
+            multiprocessing.set_start_method('spawn', force=True)
 
     def set_client(self, client):
         self.client = client

--- a/tests/test_expertise_apiv2.py
+++ b/tests/test_expertise_apiv2.py
@@ -352,7 +352,6 @@ class TestExpertiseV2():
         )
         assert response.status_code == 200, f'{response.json}'
         job_id = response.json['jobId']
-        time.sleep(2)
         response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f'{job_id}'}).json
         assert response['name'] == 'test_run'
         assert response['status'] != 'Error'
@@ -406,7 +405,6 @@ class TestExpertiseV2():
         )
         assert response.status_code == 200, f'{response.json}'
         job_id = response.json['jobId']
-        time.sleep(2)
         response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f'{job_id}'}).json
         assert response['name'] == 'test_run'
         assert response['status'] != 'Error'
@@ -508,7 +506,6 @@ class TestExpertiseV2():
         )
         assert response.status_code == 200, f'{response.json}'
         job_id = response.json['jobId']
-        time.sleep(2)
         response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f'{job_id}'}).json
         assert response['name'] == 'test_run'
         assert response['status'] != 'Error'


### PR DESCRIPTION
This PR spawns a new process when calling the expertise model to free the PyTorch CUDA context memory on success/failure