### PR TITLE
Cloud Service Fix: Allow jobs to be re-run

### DIFF
--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -874,7 +874,7 @@ class ExpertiseCloudService(BaseExpertiseService):
                     "request_key": request_key,
                 },
                 {
-                    'jobId': job_id,
+                    'jobId': config.job_id,
                     'removeOnComplete': {
                         'count': 100,
                     },

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -894,7 +894,7 @@ class ExpertiseCloudService(BaseExpertiseService):
         future = asyncio.run_coroutine_threadsafe(job.log(config_log), self.queue_loop)
         future.result()
 
-        return job_id
+        return config.job_id
 
     def get_expertise_all_status(self, user_id, query_params):
         """

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -863,7 +863,7 @@ class ExpertiseCloudService(BaseExpertiseService):
 
         config, _ = self._prepare_config(deepcopy(request))
         config_log = self._get_log_from_config(config)
-        self.logger.info(f"Adding job {job_id} to queue")
+        self.logger.info(f"Adding job {config.job_id} to queue")
 
         future = asyncio.run_coroutine_threadsafe(
             self.queue.add(

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -793,7 +793,7 @@ class ExpertiseCloudService(BaseExpertiseService):
         request = job.data['request']
 
         cloud_id = self.cloud.create_job(deepcopy(request))
-        config, token = self._prepare_config(deepcopy(request), job_id=job_id)
+        config, _ = self._prepare_config(deepcopy(request), job_id=job_id)
 
         config_log = self._get_log_from_config(config)
 
@@ -871,7 +871,6 @@ class ExpertiseCloudService(BaseExpertiseService):
                     "request": request,
                     "job_id": job_id,
                     "request_key": request_key,
-                    "token": token
                 },
                 {
                     'jobId': job_id,

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -909,6 +909,9 @@ class ExpertiseCloudService(BaseExpertiseService):
                 if cloud_job['jobId'] == redis_job.cloud_id:
                     cloud_job['name'] = redis_job.name
                     cloud_job['jobId'] = redis_job.job_id
+
+        # Sort by cdate
+        cloud_return['results'] = sorted(cloud_return['results'], key=lambda x: x['cdate'], reverse=True)
         return cloud_return
 
 

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -801,6 +801,7 @@ class ExpertiseCloudService(BaseExpertiseService):
         config.status = JobStatus.QUEUED
         config.description = descriptions[JobStatus.QUEUED]
         config.cloud_id = cloud_id
+        self.redis.save_job(config)
 
         try:
             self.logger.info(f"In polling worker...")

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -327,6 +327,7 @@ class JobConfig(object):
         return body
 
     def from_request(api_request: APIRequest,
+        job_id=None,
         starting_config = {},
         openreview_client = None,
         openreview_client_v2 = None,
@@ -345,7 +346,7 @@ class JobConfig(object):
         # Set metadata fields from request
         config.name = api_request.name
         config.user_id = get_user_id(openreview_client)
-        config.job_id = shortuuid.ShortUUID().random(length=5)
+        config.job_id = shortuuid.ShortUUID().random(length=5) if job_id is None else job_id
         config.baseurl = server_config['OPENREVIEW_BASEURL']
         config.baseurl_v2 = server_config['OPENREVIEW_BASEURL_V2']
         config.api_request = api_request    

--- a/tests/test_expertise_cloud_service.py
+++ b/tests/test_expertise_cloud_service.py
@@ -204,6 +204,7 @@ class TestExpertiseCloudService():
             )
             assert response.status_code == 200, f'{response.json}'
             job_id = response.json['jobId']
+            time.sleep(0.5)
 
             response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f'{job_id}'}).json
             assert response['name'] == 'test_run'


### PR DESCRIPTION
This PR allows jobs to be re-run by moving the spawning code to the worker process.

The function that converts the API request to a job config now accepts a `job_id` param and returns that config if it exists, otherwise it returns a new config. This is to avoid a new Redis entry with a new UUID from being made because of a retry, since a new entry would mean that the job ID returned from the original `/expertise` request would no longer be applicable.

This PR also sorts the results when GETing without a job ID, by cdate.