### PR TITLE
API: Sort results by cdate

### DIFF
--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -288,6 +288,10 @@ class BaseExpertiseService:
                         'request': config.api_request.to_json()
                     }
                 )
+
+        # Sort results by cdate
+        result['results'] = sorted(result['results'], key=lambda x: x['cdate'], reverse=True)
+
         return result
 
     def _filter_config(self, running_config):

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -1429,6 +1429,11 @@ class TestExpertiseService():
             assert match_id.startswith('~')
             assert submitter_id.startswith('~')
             assert score >= 0 and score <= 1
+
+        response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'status': 'Completed'}).json['results']
+        # Check that all results are sorted in desc cdate
+        for i in range(len(response) - 1):
+            assert response[i]['cdate'] >= response[i + 1]['cdate']
         
         # Clean up journal request
         response = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': f"{openreview_context['job_id']}", 'deleteOnGet': True}).json['results']


### PR DESCRIPTION
Resolves #213 

When getting results by querying without `jobId`, sort by latest cdate