### PR TITLE
Use public papers for expertise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 
 /tmp
 *.log
+test_pipeline/
+tests/jobs/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ openreview_expertise.egg-info
 __pycache__
 
 /tmp
-*.log
+*.log*
 test_pipeline/
 tests/jobs/

--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -68,9 +68,9 @@ class OpenReviewExpertise(object):
             return [n for n in self.openreview_client.get_notes_by_ids(ids=note_ids) if n.invitation == paper_invitation]
 
         notes_v1 = list(openreview.tools.iterget_notes(self.openreview_client, content={'authorids': author_id}))
-        notes_v1 = [note for note in notes_v1 if note.readers == ['everyone'] and  getattr(note, 'pdate', None)]
+        notes_v1 = [note for note in notes_v1 if note.readers == ['everyone']]
         notes_v2 = list(openreview.tools.iterget_notes(self.openreview_client_v2, content={'authorids': author_id}))
-        notes_v2 = [note for note in notes_v2 if note.readers == ['everyone'] and getattr(note, 'pdate', None)]
+        notes_v2 = [note for note in notes_v2 if note.readers == ['everyone']]
         return notes_v1 + notes_v2
 
     def deduplicate_publications(self, publications):

--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -68,7 +68,9 @@ class OpenReviewExpertise(object):
             return [n for n in self.openreview_client.get_notes_by_ids(ids=note_ids) if n.invitation == paper_invitation]
 
         notes_v1 = list(openreview.tools.iterget_notes(self.openreview_client, content={'authorids': author_id}))
+        notes_v1 = [note for note in notes_v1 if note.readers == ['everyone'] and  getattr(note, 'pdate', None)]
         notes_v2 = list(openreview.tools.iterget_notes(self.openreview_client_v2, content={'authorids': author_id}))
+        notes_v2 = [note for note in notes_v2 if note.readers == ['everyone'] and getattr(note, 'pdate', None)]
         return notes_v1 + notes_v2
 
     def deduplicate_publications(self, publications):

--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -288,13 +288,17 @@ class OpenReviewExpertise(object):
         self.pbar.update(1)
         member_papers = self.get_publications(member)
 
+        include_all_papers = False
+        if 'inclusion_inv' in self.config and len(self.included_ids_by_user[member]) > 0 and not any(paper['id'] in self.included_ids_by_user[member] for paper in member_papers):
+            include_all_papers = True
+
         seen_keys = set()
         filtered_papers = []
         for n in member_papers:
             paper_title = openreview.tools.get_paperhash('', n['content']['title'])
             if 'inclusion_inv' in self.config:
                 # The paper must be included or the user has included no papers
-                if paper_title and (n['id'] in self.included_ids_by_user[member] or len(self.included_ids_by_user[member]) == 0):
+                if paper_title and ((n['id'] in self.included_ids_by_user[member] or len(self.included_ids_by_user[member]) == 0) or include_all_papers):
                     filtered_papers.append(n)
             else:
                 if paper_title and n['id'] not in self.excluded_ids_by_user[member] and paper_title not in seen_keys:

--- a/tests/data/fakeData.json
+++ b/tests/data/fakeData.json
@@ -2440,7 +2440,7 @@
       },
       {
         "id": "UeHsrFSx",
-        "cdate": 1554819114,
+        "cdate": 1554819118,
         "content": {
           "title": "Dilation of Ductus Arteriosus, Percutaneous Approach",
           "abstract": "Fusce consequat. Nulla nisl. Nunc nisl."

--- a/tests/test_create_dataset.py
+++ b/tests/test_create_dataset.py
@@ -15,7 +15,7 @@ def test_convert_to_list(client, openreview_client):
 def test_get_papers_from_group(client, openreview_client):
     or_expertise = OpenReviewExpertise(client, openreview_client, {})
     all_papers = or_expertise.get_papers_from_group('DEF.cc/Reviewers')
-    assert len(all_papers) == 146
+    assert len(all_papers) == 45
     if os.path.isfile('publications_by_profile_id.json'):
         os.remove('publications_by_profile_id.json')
 

--- a/tests/test_create_dataset.py
+++ b/tests/test_create_dataset.py
@@ -15,7 +15,7 @@ def test_convert_to_list(client, openreview_client):
 def test_get_papers_from_group(client, openreview_client):
     or_expertise = OpenReviewExpertise(client, openreview_client, {})
     all_papers = or_expertise.get_papers_from_group('DEF.cc/Reviewers')
-    assert len(all_papers) == 45
+    assert len(all_papers) == 146
     if os.path.isfile('publications_by_profile_id.json'):
         os.remove('publications_by_profile_id.json')
 
@@ -47,7 +47,7 @@ def test_get_publications(client, openreview_client):
     assert publications == []
 
     publications = or_expertise.get_publications('~Perry_Volkman1')
-    assert len(publications) == 1
+    assert len(publications) == 3
 
     minimum_pub_date = 1554819115
     config = {
@@ -57,7 +57,7 @@ def test_get_publications(client, openreview_client):
     }
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     publications = or_expertise.get_publications('~Perry_Volkman1')
-    assert len(publications) == 1
+    assert len(publications) == 3
     for publication in publications:
         assert publication['cdate'] > minimum_pub_date
 
@@ -69,7 +69,7 @@ def test_get_publications(client, openreview_client):
     }
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     publications = or_expertise.get_publications('~Perry_Volkman1')
-    assert len(publications) == 1
+    assert len(publications) == 2
     for publication in publications:
         assert publication['cdate'] > minimum_pub_date
 
@@ -96,7 +96,7 @@ def test_get_publications(client, openreview_client):
     }
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     publications = or_expertise.get_publications('~Perry_Volkman1')
-    assert len(publications) == 1
+    assert len(publications) == 3
     for publication in publications:
         assert publication['cdate'] > minimum_pub_date
 
@@ -111,7 +111,7 @@ def test_get_publications(client, openreview_client):
     }
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     publications = or_expertise.get_publications('~Perry_Volkman1')
-    assert len(publications) == 1
+    assert len(publications) == 3
     for publication in publications:
         assert publication['cdate'] > minimum_pub_date
 
@@ -161,10 +161,12 @@ def test_retrieve_expertise(get_paperhash, client, openreview_client):
     profiles = data['profiles']
     for profile in profiles:
         if len(profile['publications']) > 0:
-            if profile['id'] in exclude_ids:
+            if profile['id'] == '~Perry_Volkman1':
+                assert len(expertise[profile['id']]) < len(profile['publications'])
+            elif profile['id'] in exclude_ids:
                 assert len(expertise[profile['id']]) == 0
             else:
-                assert len(expertise[profile['id']]) < len(profile['publications'])
+                assert len(expertise[profile['id']]) == len(profile['publications'])
 
 def test_get_submissions_from_invitation(client, openreview_client):
     config = {
@@ -202,7 +204,7 @@ def test_deduplication(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, {})
 
     publications = or_expertise.get_publications('~Harold_Rice1')
-    assert len(publications) == 1
+    assert len(publications) == 3
 
     note = openreview.Note(
         invitation = 'openreview.net/-/paper',
@@ -216,7 +218,7 @@ def test_deduplication(client, openreview_client, helpers):
     note = test_user_client.post_note(note)
 
     publications = or_expertise.get_publications('~Harold_Rice1')
-    assert len(publications) == 1
+    assert len(publications) == 3
 
 def test_expertise_selection(client, openreview_client, helpers):
     config = {
@@ -229,7 +231,7 @@ def test_expertise_selection(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
 
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 1
+    assert len(expertise['~Harold_Rice1']) == 3
 
     note = openreview.api.Note(
         content = {
@@ -249,7 +251,7 @@ def test_expertise_selection(client, openreview_client, helpers):
     )
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 2 # New note added
+    assert len(expertise['~Harold_Rice1']) == 4 # New note added
     
     user_client = openreview.Client(username='strevino0@ox.ac.uk', password=helpers.strong_password)
     edge = openreview.Edge(
@@ -266,7 +268,7 @@ def test_expertise_selection(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     or_expertise.excluded_ids_by_user = or_expertise.exclude()
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 1
+    assert len(expertise['~Harold_Rice1']) == 3
 
     # Test API2 expertise selection
 def test_expertise_selection_api2(client, openreview_client, helpers):
@@ -281,7 +283,7 @@ def test_expertise_selection_api2(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
 
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~C.V._Lastname1']) == 0, expertise
+    assert len(expertise['~C.V._Lastname1']) == 1, expertise
 
     test_user_client = openreview.api.OpenReviewClient(username='test@google.com', password=helpers.strong_password)
     note_1 = test_user_client.post_note_edit(
@@ -302,7 +304,7 @@ def test_expertise_selection_api2(client, openreview_client, helpers):
 
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~C.V._Lastname1']) == 0
+    assert len(expertise['~C.V._Lastname1']) == 1
     
     user_client = openreview.api.OpenReviewClient(username='testdots@google.com', password=helpers.strong_password)
     user_client.post_edge(
@@ -318,7 +320,7 @@ def test_expertise_selection_api2(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     or_expertise.excluded_ids_by_user = or_expertise.exclude()
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~C.V._Lastname1']) == 0
+    assert len(expertise['~C.V._Lastname1']) == 1
 
 
 def test_expertise_inclusion(client, openreview_client, helpers):
@@ -332,7 +334,7 @@ def test_expertise_inclusion(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
 
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 2 # No edges use all publications
+    assert len(expertise['~Harold_Rice1']) == 4 # No edges use all publications
 
     note = openreview.api.Note(
         content = {
@@ -367,7 +369,7 @@ def test_expertise_inclusion(client, openreview_client, helpers):
     )
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 4 # New notes added
+    assert len(expertise['~Harold_Rice1']) == 6 # New notes added
     
     # Post this edge to both ABC and HIJ, ABC will be deleted, HIJ will be used for the API tests
     edge = openreview.Edge(

--- a/tests/test_create_dataset.py
+++ b/tests/test_create_dataset.py
@@ -231,29 +231,30 @@ def test_expertise_selection(client, openreview_client, helpers):
     expertise = or_expertise.retrieve_expertise()
     assert len(expertise['~Harold_Rice1']) == 1
 
-    note = openreview.Note(
-        invitation = 'openreview.net/-/paper',
-        readers = ['everyone'],
-        writers = ['~SomeTest_User1'],
-        signatures = ['~SomeTest_User1'],
+    note = openreview.api.Note(
         content = {
-            "title": "test_exclude",
-            "abstract": original_note.content['abstract'],
-            "authorids": original_note.content['authorids']
+            "title": { 'value': "test_exclude_def" },
+            "abstract": { 'value': original_note.content['abstract'] },
+            "authors": { 'value': original_note.content['authorids'] },
+            "authorids": { 'value': original_note.content['authorids'] },
         },
-        cdate = 1554819115
+        pdate = 1554819115,
+        license = 'CC BY-SA 4.0'
     )
 
-    test_user_client = openreview.Client(username='test@google.com', password=helpers.strong_password)
-    note = test_user_client.post_note(note)
+    note_edit = openreview_client.post_note_edit(
+        invitation='openreview.net/Archive/-/Direct_Upload',
+        signatures = ['~SomeTest_User1'],
+        note=note
+    )
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 1
+    assert len(expertise['~Harold_Rice1']) == 2 # New note added
     
     user_client = openreview.Client(username='strevino0@ox.ac.uk', password=helpers.strong_password)
     edge = openreview.Edge(
                         invitation='DEF.cc/-/Expertise_Selection',
-                        head=note.id,
+                        head=note_edit['note']['id'],
                         tail='~Harold_Rice1',
                         label='Exclude',
                         readers=['DEF.cc', '~Harold_Rice1'],
@@ -331,44 +332,47 @@ def test_expertise_inclusion(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
 
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 1
+    assert len(expertise['~Harold_Rice1']) == 2 # No edges use all publications
 
-    note = openreview.Note(
-        invitation = 'openreview.net/-/paper',
-        readers = ['everyone'],
-        writers = ['~SomeTest_User1'],
-        signatures = ['~SomeTest_User1'],
+    note = openreview.api.Note(
         content = {
-            "title": "test_include",
-            "abstract": original_note.content['abstract'],
-            "authorids": original_note.content['authorids']
+            "title": { 'value': "test_include_abchij" },
+            "abstract": { 'value': original_note.content['abstract'] },
+            "authors": { 'value': original_note.content['authorids'] },
+            "authorids": { 'value': original_note.content['authorids'] },
         },
-        cdate = 1554819115
+        pdate = 1554819115,
+        license = 'CC BY-SA 4.0'
     )
-    exclude_note = openreview.Note(
-        invitation = 'openreview.net/-/paper',
-        readers = ['everyone'],
-        writers = ['~SomeTest_User1'],
-        signatures = ['~SomeTest_User1'],
+    exclude_note = openreview.api.Note(
         content = {
-            "title": "test_include",
-            "abstract": original_note.content['abstract'],
-            "authorids": original_note.content['authorids']
+            "title": { 'value': "test_exclude_abchij" },
+            "abstract": { 'value': original_note.content['abstract'] },
+            "authors": { 'value': original_note.content['authorids'] },
+            "authorids": { 'value': original_note.content['authorids'] },
         },
-        cdate = 1554819115
+        pdate = 1554819115,
+        license = 'CC BY-SA 4.0'
     )
 
-    test_user_client = openreview.Client(username='test@google.com', password=helpers.strong_password)
-    note = test_user_client.post_note(note)
-    exclude_note = test_user_client.post_note(exclude_note)
+    note_edit = openreview_client.post_note_edit(
+        invitation='openreview.net/Archive/-/Direct_Upload',
+        signatures = ['~SomeTest_User1'],
+        note=note
+    )
+    exclude_note_edit = openreview_client.post_note_edit(
+        invitation='openreview.net/Archive/-/Direct_Upload',
+        signatures = ['~SomeTest_User1'],
+        note=exclude_note
+    )
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 1
+    assert len(expertise['~Harold_Rice1']) == 4 # New notes added
     
     # Post this edge to both ABC and HIJ, ABC will be deleted, HIJ will be used for the API tests
     edge = openreview.Edge(
                         invitation='HIJ.cc/-/Expertise_Selection',
-                        head=note.id,
+                        head=note_edit['note']['id'],
                         tail='~Harold_Rice1',
                         label='Include',
                         readers=['HIJ.cc', '~Harold_Rice1'],
@@ -379,7 +383,7 @@ def test_expertise_inclusion(client, openreview_client, helpers):
 
     edge = openreview.Edge(
         invitation='ABC.cc/-/Expertise_Selection',
-        head=note.id,
+        head=note_edit['note']['id'],
         tail='~Harold_Rice1',
         label='Include',
         readers=['ABC.cc', '~Harold_Rice1'],
@@ -424,7 +428,7 @@ def test_expertise_inclusion(client, openreview_client, helpers):
     client.post_invitation(inv)
     edge = openreview.Edge(
                         invitation='ABC.cc/-/Expertise_Selection',
-                        head=exclude_note.id,
+                        head=exclude_note_edit['note']['id'],
                         tail='~Harold_Rice1',
                         label='Exclude',
                         readers=['ABC.cc', '~Harold_Rice1'],
@@ -473,7 +477,7 @@ def test_expertise_inclusion(client, openreview_client, helpers):
     or_expertise.included_ids_by_user = or_expertise.include()
     assert len(or_expertise.included_ids_by_user['~Harold_Rice1']) == 1
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 0
+    assert len(expertise['~Harold_Rice1']) == 1
 
     # Clear the inclusion edges for ABC
     client.delete_edges(invitation='ABC.cc/-/Expertise_Selection')

--- a/tests/test_create_dataset.py
+++ b/tests/test_create_dataset.py
@@ -47,7 +47,7 @@ def test_get_publications(client, openreview_client):
     assert publications == []
 
     publications = or_expertise.get_publications('~Perry_Volkman1')
-    assert len(publications) == 3
+    assert len(publications) == 1
 
     minimum_pub_date = 1554819115
     config = {
@@ -57,7 +57,7 @@ def test_get_publications(client, openreview_client):
     }
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     publications = or_expertise.get_publications('~Perry_Volkman1')
-    assert len(publications) == 2
+    assert len(publications) == 1
     for publication in publications:
         assert publication['cdate'] > minimum_pub_date
 
@@ -69,7 +69,7 @@ def test_get_publications(client, openreview_client):
     }
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     publications = or_expertise.get_publications('~Perry_Volkman1')
-    assert len(publications) == 2
+    assert len(publications) == 1
     for publication in publications:
         assert publication['cdate'] > minimum_pub_date
 
@@ -96,7 +96,7 @@ def test_get_publications(client, openreview_client):
     }
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     publications = or_expertise.get_publications('~Perry_Volkman1')
-    assert len(publications) == 2
+    assert len(publications) == 1
     for publication in publications:
         assert publication['cdate'] > minimum_pub_date
 
@@ -111,7 +111,7 @@ def test_get_publications(client, openreview_client):
     }
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     publications = or_expertise.get_publications('~Perry_Volkman1')
-    assert len(publications) == 2
+    assert len(publications) == 1
     for publication in publications:
         assert publication['cdate'] > minimum_pub_date
 
@@ -161,12 +161,10 @@ def test_retrieve_expertise(get_paperhash, client, openreview_client):
     profiles = data['profiles']
     for profile in profiles:
         if len(profile['publications']) > 0:
-            if profile['id'] == '~Perry_Volkman1':
-                assert len(expertise[profile['id']]) < len(profile['publications'])
-            elif profile['id'] in exclude_ids:
+            if profile['id'] in exclude_ids:
                 assert len(expertise[profile['id']]) == 0
             else:
-                assert len(expertise[profile['id']]) == len(profile['publications'])
+                assert len(expertise[profile['id']]) < len(profile['publications'])
 
 def test_get_submissions_from_invitation(client, openreview_client):
     config = {
@@ -204,7 +202,7 @@ def test_deduplication(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, {})
 
     publications = or_expertise.get_publications('~Harold_Rice1')
-    assert len(publications) == 3
+    assert len(publications) == 1
 
     note = openreview.Note(
         invitation = 'openreview.net/-/paper',
@@ -218,7 +216,7 @@ def test_deduplication(client, openreview_client, helpers):
     note = test_user_client.post_note(note)
 
     publications = or_expertise.get_publications('~Harold_Rice1')
-    assert len(publications) == 3
+    assert len(publications) == 1
 
 def test_expertise_selection(client, openreview_client, helpers):
     config = {
@@ -231,7 +229,7 @@ def test_expertise_selection(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
 
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 3
+    assert len(expertise['~Harold_Rice1']) == 1
 
     note = openreview.Note(
         invitation = 'openreview.net/-/paper',
@@ -250,7 +248,7 @@ def test_expertise_selection(client, openreview_client, helpers):
     note = test_user_client.post_note(note)
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 4
+    assert len(expertise['~Harold_Rice1']) == 1
     
     user_client = openreview.Client(username='strevino0@ox.ac.uk', password=helpers.strong_password)
     edge = openreview.Edge(
@@ -267,7 +265,7 @@ def test_expertise_selection(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     or_expertise.excluded_ids_by_user = or_expertise.exclude()
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 3
+    assert len(expertise['~Harold_Rice1']) == 1
 
     # Test API2 expertise selection
 def test_expertise_selection_api2(client, openreview_client, helpers):
@@ -282,7 +280,7 @@ def test_expertise_selection_api2(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
 
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~C.V._Lastname1']) == 1, expertise
+    assert len(expertise['~C.V._Lastname1']) == 0, expertise
 
     test_user_client = openreview.api.OpenReviewClient(username='test@google.com', password=helpers.strong_password)
     note_1 = test_user_client.post_note_edit(
@@ -303,7 +301,7 @@ def test_expertise_selection_api2(client, openreview_client, helpers):
 
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~C.V._Lastname1']) == 2
+    assert len(expertise['~C.V._Lastname1']) == 0
     
     user_client = openreview.api.OpenReviewClient(username='testdots@google.com', password=helpers.strong_password)
     user_client.post_edge(
@@ -319,7 +317,7 @@ def test_expertise_selection_api2(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     or_expertise.excluded_ids_by_user = or_expertise.exclude()
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~C.V._Lastname1']) == 1
+    assert len(expertise['~C.V._Lastname1']) == 0
 
 
 def test_expertise_inclusion(client, openreview_client, helpers):
@@ -333,7 +331,7 @@ def test_expertise_inclusion(client, openreview_client, helpers):
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
 
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 4
+    assert len(expertise['~Harold_Rice1']) == 1
 
     note = openreview.Note(
         invitation = 'openreview.net/-/paper',
@@ -365,7 +363,7 @@ def test_expertise_inclusion(client, openreview_client, helpers):
     exclude_note = test_user_client.post_note(exclude_note)
     or_expertise = OpenReviewExpertise(client, openreview_client, config)
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 6
+    assert len(expertise['~Harold_Rice1']) == 1
     
     # Post this edge to both ABC and HIJ, ABC will be deleted, HIJ will be used for the API tests
     edge = openreview.Edge(
@@ -475,7 +473,7 @@ def test_expertise_inclusion(client, openreview_client, helpers):
     or_expertise.included_ids_by_user = or_expertise.include()
     assert len(or_expertise.included_ids_by_user['~Harold_Rice1']) == 1
     expertise = or_expertise.retrieve_expertise()
-    assert len(expertise['~Harold_Rice1']) == 1
+    assert len(expertise['~Harold_Rice1']) == 0
 
     # Clear the inclusion edges for ABC
     client.delete_edges(invitation='ABC.cc/-/Expertise_Selection')

--- a/tests/test_create_journal.py
+++ b/tests/test_create_journal.py
@@ -88,7 +88,7 @@ class TestJournal():
                         existing_titles = [pub.content.get('title') for pub in existing_pubs]
 
                         if content.get('title') not in existing_titles:
-                            publication_note = openreview_client.post_note_edit(
+                            submission_note = openreview_client.post_note_edit(
                                 invitation = 'TMLR/-/Submission',
                                 signatures = ['~Super_User1'],
                                 note = Note(
@@ -103,6 +103,19 @@ class TestJournal():
                                         'competing_interests': { 'value': 'None beyond the authors normal conflict of interests'},
                                         'human_subjects_reporting': { 'value': 'Not applicable'}
                                     }
+                                ))
+                            publication_note = openreview_client.post_note_edit(
+                                invitation = 'openreview.net/Archive/-/Direct_Upload',
+                                signatures = [authorid],
+                                note = Note(
+                                    pdate = cdate,
+                                    content = {
+                                        'title': { 'value': content.get('title').get('value') },
+                                        'abstract': { 'value': content.get('abstract').get('value') },
+                                        'authors': { 'value': [name]},
+                                        'authorids': { 'value': [authorid]},
+                                    },
+                                    license = 'CC BY-SA 4.0'
                                 ))
             
         with open('tests/data/fakeData.json') as json_file:

--- a/tests/test_create_journal.py
+++ b/tests/test_create_journal.py
@@ -35,8 +35,8 @@ class TestJournal():
         journal=Journal(openreview_client, venue_id, '1234', contact_info='tmlr@jmlr.org', full_name='Transactions on Machine Learning Research', short_name='TMLR', submission_name='Submission')
         journal.setup(support_role='fabian@mail.com', editors=['~Raia_Hadsell1', '~Kyunghyun_Cho1'])
 
-        openreview_client.add_members_to_group('TMLR/Action_Editors', ['~Raia_Hadsell1', '~Kyunghyun_Cho1'])
-        openreview_client.add_members_to_group('TMLR/Reviewers', ['~Raia_Hadsell1', '~Kyunghyun_Cho1'])
+        openreview_client.add_members_to_group('TMLR/Action_Editors', ['~Raia_Hadsell1', '~Kyunghyun_Cho1', '~Margherita_Hilpert1'])
+        openreview_client.add_members_to_group('TMLR/Reviewers', ['~Raia_Hadsell1', '~Kyunghyun_Cho1', '~Margherita_Hilpert1'])
     
     def test_post_submissions(self, client, openreview_client, helpers, test_client):
         # Post submission with a test author id

--- a/tests/test_expertise_apiv2.py
+++ b/tests/test_expertise_apiv2.py
@@ -88,7 +88,7 @@ class TestExpertiseV2():
 
         or_expertise = OpenReviewExpertise(client, openreview_client, config)
         publications = or_expertise.get_publications('~Harold_Rice1')
-        assert len(publications) == 3
+        assert len(publications) == 1
         for pub in publications:
             content = pub['content']
             assert isinstance(content['title'], str)
@@ -474,7 +474,7 @@ class TestExpertiseV2():
         assert response['description'] == 'Job is complete and the computed scores are ready'
 
         results = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': job_id}).json['results']       
-        assert len(results) == 10
+        assert len(results) == 5
 
     def test_specter2_scincl(self, openreview_client, openreview_context, celery_session_app, celery_session_worker):
         # Submit a working job and return the job ID

--- a/tests/test_expertise_apiv2.py
+++ b/tests/test_expertise_apiv2.py
@@ -88,7 +88,7 @@ class TestExpertiseV2():
 
         or_expertise = OpenReviewExpertise(client, openreview_client, config)
         publications = or_expertise.get_publications('~Harold_Rice1')
-        assert len(publications) == 1
+        assert len(publications) == 3 ## 3 top recent publications
         for pub in publications:
             content = pub['content']
             assert isinstance(content['title'], str)
@@ -474,7 +474,7 @@ class TestExpertiseV2():
         assert response['description'] == 'Job is complete and the computed scores are ready'
 
         results = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': job_id}).json['results']       
-        assert len(results) == 5
+        assert len(results) == 15 # 3 editors x 5 submissions/publications from Raia/Kyunghyun
 
     def test_specter2_scincl(self, openreview_client, openreview_context, celery_session_app, celery_session_worker):
         # Submit a working job and return the job ID

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -1403,7 +1403,8 @@ class TestExpertiseService():
         no_inclusion = sum(d.stat().st_size for d in os.scandir(f"./tests/jobs/{openreview_context['job_id']}/archives") if d.is_file())
         with_inclusion = sum(d.stat().st_size for d in os.scandir(f"./tests/jobs/{job_id}/archives") if d.is_file())
         with_exclusion = sum(d.stat().st_size for d in os.scandir(f"./tests/jobs/{openreview_context['exclusion_id']}/archives") if d.is_file())
-        assert sum(1 for _ in os.scandir(f"./tests/jobs/{job_id}/archives")) == 4
+        print(list(os.scandir(f"./tests/jobs/{job_id}/archives")))
+        assert sum(1 for _ in os.scandir(f"./tests/jobs/{job_id}/archives")) == 2 # One member as no publications, the other only has TMLR submissions
         assert os.path.getsize(f"./tests/jobs/{job_id}/archives/~Harold_Rice1.jsonl") < os.path.getsize(f"./tests/jobs/{openreview_context['job_id']}/archives/~Harold_Rice1.jsonl")
         assert with_inclusion < no_inclusion
         assert with_inclusion < with_exclusion
@@ -1420,7 +1421,7 @@ class TestExpertiseService():
         # Searches for journal results from the given job_id assuming the job has completed
         response = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': f"{openreview_context['job_id']}"})
         metadata = response.json['metadata']
-        assert metadata['submission_count'] == 2
+        assert metadata['submission_count'] == 5
         response = response.json['results']
         for item in response:
             match_id, submitter_id, score = item['match_member'], item['submission_member'], float(item['score'])

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -565,8 +565,8 @@ class TestExpertiseService():
         # Check members
         assert "~Harold_Rice1" in all_users
         assert "~Zonia_Willms1" in all_users
-        assert "~Royal_Toy1" not in all_users
-        assert "~C.V._Lastname1" not in all_users
+        assert "~Royal_Toy1" in all_users
+        assert "~C.V._Lastname1" in all_users
 
 
     def test_compare_results_for_identical_jobs(self, openreview_client, openreview_context, celery_session_app, celery_session_worker):
@@ -1182,11 +1182,11 @@ class TestExpertiseService():
         assert "~Zonia_Willms1" in submission_users
         assert "~Zonia_Willms1" in match_users
 
-        assert "~Royal_Toy1" not in submission_users
-        assert "~Royal_Toy1" not in match_users
+        assert "~Royal_Toy1" in submission_users
+        assert "~Royal_Toy1" in match_users
 
-        assert "~C.V._Lastname1" not in submission_users
-        assert "~C.V._Lastname1" not in match_users
+        assert "~C.V._Lastname1" in submission_users
+        assert "~C.V._Lastname1" in match_users
     
     def test_request_group_exclusion_exclusion(self, openreview_client, openreview_context, celery_session_app, celery_session_worker):
         # Test expertise exclusion - both the archives and submissions should be smaller than the previous test's
@@ -1404,7 +1404,7 @@ class TestExpertiseService():
         with_inclusion = sum(d.stat().st_size for d in os.scandir(f"./tests/jobs/{job_id}/archives") if d.is_file())
         with_exclusion = sum(d.stat().st_size for d in os.scandir(f"./tests/jobs/{openreview_context['exclusion_id']}/archives") if d.is_file())
         print(list(os.scandir(f"./tests/jobs/{job_id}/archives")))
-        assert sum(1 for _ in os.scandir(f"./tests/jobs/{job_id}/archives")) == 2 # One member as no publications, the other only has TMLR submissions
+        assert sum(1 for _ in os.scandir(f"./tests/jobs/{job_id}/archives")) == 4 # One member as no publications, the other only has TMLR submissions
         assert os.path.getsize(f"./tests/jobs/{job_id}/archives/~Harold_Rice1.jsonl") < os.path.getsize(f"./tests/jobs/{openreview_context['job_id']}/archives/~Harold_Rice1.jsonl")
         assert with_inclusion < no_inclusion
         assert with_inclusion < with_exclusion
@@ -1421,7 +1421,7 @@ class TestExpertiseService():
         # Searches for journal results from the given job_id assuming the job has completed
         response = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': f"{openreview_context['job_id']}"})
         metadata = response.json['metadata']
-        assert metadata['submission_count'] == 5
+        assert metadata['submission_count'] == 10
         response = response.json['results']
         for item in response:
             match_id, submitter_id, score = item['match_member'], item['submission_member'], float(item['score'])

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -565,8 +565,8 @@ class TestExpertiseService():
         # Check members
         assert "~Harold_Rice1" in all_users
         assert "~Zonia_Willms1" in all_users
-        assert "~Royal_Toy1" in all_users
-        assert "~C.V._Lastname1" in all_users
+        assert "~Royal_Toy1" not in all_users
+        assert "~C.V._Lastname1" not in all_users
 
 
     def test_compare_results_for_identical_jobs(self, openreview_client, openreview_context, celery_session_app, celery_session_worker):
@@ -1182,11 +1182,11 @@ class TestExpertiseService():
         assert "~Zonia_Willms1" in submission_users
         assert "~Zonia_Willms1" in match_users
 
-        assert "~Royal_Toy1" in submission_users
-        assert "~Royal_Toy1" in match_users
+        assert "~Royal_Toy1" not in submission_users
+        assert "~Royal_Toy1" not in match_users
 
-        assert "~C.V._Lastname1" in submission_users
-        assert "~C.V._Lastname1" in match_users
+        assert "~C.V._Lastname1" not in submission_users
+        assert "~C.V._Lastname1" not in match_users
     
     def test_request_group_exclusion_exclusion(self, openreview_client, openreview_context, celery_session_app, celery_session_worker):
         # Test expertise exclusion - both the archives and submissions should be smaller than the previous test's
@@ -1420,7 +1420,7 @@ class TestExpertiseService():
         # Searches for journal results from the given job_id assuming the job has completed
         response = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': f"{openreview_context['job_id']}"})
         metadata = response.json['metadata']
-        assert metadata['submission_count'] == 10
+        assert metadata['submission_count'] == 2
         response = response.json['results']
         for item in response:
             match_id, submitter_id, score = item['match_member'], item['submission_member'], float(item['score'])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -88,7 +88,7 @@ def test_run_pipeline(mock_load_model_artifacts, mock_gcs_client, mock_execute_e
         '{"submission": "test_user", "user": "note1", "score": 0.5}\n{"submission": "test_user", "user": "note2", "score": 0.5}'
     )
     mock_blob.upload_from_string.assert_any_call(
-        '{"submission_count": 2, "no_publications_count": 2, "no_publications": ["~Royal_Toy1", "~C.V._Lastname1"], "no_profile": []}'
+        '{"submission_count": 2, "no_publications_count": 2, "no_publications": ["~C.V._Lastname1", "~Royal_Toy1"], "no_profile": []}'
     )
     mock_blob.upload_from_string.assert_any_call(
         json.dumps({"paper_id": "paperId", "embedding": [0.1, 0.2, 0.3]})
@@ -183,7 +183,7 @@ def test_run_pipeline_group(mock_load_model_artifacts, mock_gcs_client, mock_exe
         '{"match_member": "test_user", "submission_member": "sub_user", "score": 0.5}\n{"match_member": "test_user", "submission_member": "sub_user", "score": 0.5}'
     )
     mock_blob.upload_from_string.assert_any_call(
-        '{"submission_count": 2, "no_publications_count": 2, "no_publications": ["~Royal_Toy1", "~C.V._Lastname1"], "no_profile": [], "no_profile_submission": []}'
+        '{"submission_count": 5, "no_publications_count": 2, "no_publications": ["~C.V._Lastname1", "~Royal_Toy1"], "no_profile": [], "no_profile_submission": []}'
     )
     mock_blob.upload_from_string.assert_any_call(
         json.dumps({"paper_id": "paperId", "embedding": [0.1, 0.2, 0.3]})

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -88,13 +88,13 @@ def test_run_pipeline(mock_load_model_artifacts, mock_gcs_client, mock_execute_e
         '{"submission": "test_user", "user": "note1", "score": 0.5}\n{"submission": "test_user", "user": "note2", "score": 0.5}'
     )
     mock_blob.upload_from_string.assert_any_call(
-        '{"submission_count": 2, "no_publications_count": 0, "no_publications": [], "no_profile": []}'
+        '{"submission_count": 2, "no_publications_count": 2, "no_publications": ["~Royal_Toy1", "~C.V._Lastname1"], "no_profile": []}'
     )
     mock_blob.upload_from_string.assert_any_call(
         json.dumps({"paper_id": "paperId", "embedding": [0.1, 0.2, 0.3]})
     )
     publication_calls = [call for call in mock_blob.upload_from_string.call_args_list if '"content":' in call.args[0]]
-    assert len(publication_calls) == 4
+    assert len(publication_calls) == 2
 
     shutil.rmtree(working_dir)  # Clean up
 
@@ -183,12 +183,12 @@ def test_run_pipeline_group(mock_load_model_artifacts, mock_gcs_client, mock_exe
         '{"match_member": "test_user", "submission_member": "sub_user", "score": 0.5}\n{"match_member": "test_user", "submission_member": "sub_user", "score": 0.5}'
     )
     mock_blob.upload_from_string.assert_any_call(
-        '{"submission_count": 10, "no_publications_count": 0, "no_publications": [], "no_profile": [], "no_profile_submission": []}'
+        '{"submission_count": 2, "no_publications_count": 2, "no_publications": ["~Royal_Toy1", "~C.V._Lastname1"], "no_profile": [], "no_profile_submission": []}'
     )
     mock_blob.upload_from_string.assert_any_call(
         json.dumps({"paper_id": "paperId", "embedding": [0.1, 0.2, 0.3]})
     )
     publication_calls = [call for call in mock_blob.upload_from_string.call_args_list if '"content":' in call.args[0]]
-    assert len(publication_calls) == 4
+    assert len(publication_calls) == 2
 
     shutil.rmtree(working_dir)  # Clean up

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -88,13 +88,13 @@ def test_run_pipeline(mock_load_model_artifacts, mock_gcs_client, mock_execute_e
         '{"submission": "test_user", "user": "note1", "score": 0.5}\n{"submission": "test_user", "user": "note2", "score": 0.5}'
     )
     mock_blob.upload_from_string.assert_any_call(
-        '{"submission_count": 2, "no_publications_count": 2, "no_publications": ["~C.V._Lastname1", "~Royal_Toy1"], "no_profile": []}'
+        '{"submission_count": 2, "no_publications_count": 0, "no_publications": [], "no_profile": []}'
     )
     mock_blob.upload_from_string.assert_any_call(
         json.dumps({"paper_id": "paperId", "embedding": [0.1, 0.2, 0.3]})
     )
     publication_calls = [call for call in mock_blob.upload_from_string.call_args_list if '"content":' in call.args[0]]
-    assert len(publication_calls) == 2
+    assert len(publication_calls) == 4
 
     shutil.rmtree(working_dir)  # Clean up
 
@@ -183,12 +183,12 @@ def test_run_pipeline_group(mock_load_model_artifacts, mock_gcs_client, mock_exe
         '{"match_member": "test_user", "submission_member": "sub_user", "score": 0.5}\n{"match_member": "test_user", "submission_member": "sub_user", "score": 0.5}'
     )
     mock_blob.upload_from_string.assert_any_call(
-        '{"submission_count": 5, "no_publications_count": 2, "no_publications": ["~C.V._Lastname1", "~Royal_Toy1"], "no_profile": [], "no_profile_submission": []}'
+        '{"submission_count": 10, "no_publications_count": 0, "no_publications": [], "no_profile": [], "no_profile_submission": []}'
     )
     mock_blob.upload_from_string.assert_any_call(
         json.dumps({"paper_id": "paperId", "embedding": [0.1, 0.2, 0.3]})
     )
     publication_calls = [call for call in mock_blob.upload_from_string.call_args_list if '"content":' in call.args[0]]
-    assert len(publication_calls) == 2
+    assert len(publication_calls) == 4
 
     shutil.rmtree(working_dir)  # Clean up


### PR DESCRIPTION
This PR filters publication notes for `readers = everyone`. This will ensure we are using public papers for score computation.

In a new PR we will add the filter for `pdate` and make the same change for the Expertise Selection UI.