### PR TITLE
Expertise API: Fix Singleton Condition

### DIFF
--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -792,7 +792,7 @@ class ExpertiseCloudService(BaseExpertiseService):
         request = job.data['request']
         redis_id = job.data['redis_id']
 
-        cloud_id = self.cloud.create_job(deepcopy(request))
+        cloud_id = self.cloud.create_job(deepcopy(request), user_id = user_id)
         config = self.redis.load_job(redis_id, user_id)
         config.mdate = int(time.time() * 1000)
         config.status = JobStatus.QUEUED

--- a/expertise/service/routes.py
+++ b/expertise/service/routes.py
@@ -125,7 +125,7 @@ def expertise():
             raise openreview.OpenReviewException("Request already in process")
 
         try:
-            job_id = expertise_service.start_expertise(user_request)
+            job_id = expertise_service.start_expertise(user_request, openreview_client, openreview_client_v2)
             expertise_service.redis.db.delete(request_key)
         except Exception as error_handle:
             expertise_service.redis.db.delete(request_key)

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -698,7 +698,7 @@ class GCPInterface(object):
         elif 'id' in note_entity:
             return f"pid-{note_entity['id']}-{group_entity['memberOf']}"
 
-    def create_job(self, json_request: dict):
+    def create_job(self, json_request: dict, user_id: str = None):
         def create_folder(bucket_name, folder_path):
             client = storage.Client()
             bucket = client.get_bucket(bucket_name)
@@ -750,7 +750,7 @@ class GCPInterface(object):
         #data['dump_archives'] = True
 
         # Deleted metadata fields before hitting the pipeline
-        data['user_id'] = get_user_id(self.client)
+        data['user_id'] = user_id if user_id else get_user_id(self.client)
         data['cdate'] = int(time.time() * 1000)
 
         write_json_to_gcs(self.bucket_name, folder_path, self.request_fname, data)

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -698,7 +698,7 @@ class GCPInterface(object):
         elif 'id' in note_entity:
             return f"pid-{note_entity['id']}-{group_entity['memberOf']}"
 
-    def create_job(self, json_request: dict, user_id: str = None):
+    def create_job(self, json_request: dict, user_id: str = None, client = None):
         def create_folder(bucket_name, folder_path):
             client = storage.Client()
             bucket = client.get_bucket(bucket_name)
@@ -731,6 +731,7 @@ class GCPInterface(object):
             )
             self.logger.info(f"JSON file '{file_name}' written to '{folder_path}' in bucket '{bucket_name}'.")
 
+        or_client = client if client else self.client
         api_request = APIRequest(json_request)
         job_id = GCPInterface._generate_vertex_prefix(api_request) + '-' + datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         valid_vertex_id = job_id.replace('/','-').replace(':','-').replace('_','-').replace('.', '-').lower()
@@ -742,15 +743,15 @@ class GCPInterface(object):
         data['name'] = valid_vertex_id
 
         # Popped fields
-        data['token'] = self.client.token
-        data['baseurl_v1'] = openreview.tools.get_base_urls(self.client)[0]
-        data['baseurl_v2'] = openreview.tools.get_base_urls(self.client)[1]
+        data['token'] = or_client.token
+        data['baseurl_v1'] = openreview.tools.get_base_urls(or_client)[0]
+        data['baseurl_v2'] = openreview.tools.get_base_urls(or_client)[1]
         data['gcs_folder'] = f"gs://{self.bucket_name}/{folder_path}"
         #data['dump_embs'] = True
         #data['dump_archives'] = True
 
         # Deleted metadata fields before hitting the pipeline
-        data['user_id'] = user_id if user_id else get_user_id(self.client)
+        data['user_id'] = user_id if user_id else get_user_id(or_client)
         data['cdate'] = int(time.time() * 1000)
 
         write_json_to_gcs(self.bucket_name, folder_path, self.request_fname, data)


### PR DESCRIPTION
This PR fixes an issue where the `user_id` stored in Redis and in the queue does not match the `user_id` stored in GCS. The issue is most likely the sharing of the `ExpertiseCloudInstance` in `routes.py` where we are overwriting the clients per request.

This PR addresses that by explicitly passing the user_id from the request to the `create_job` function