### PR TITLE
Feature: Add support to select score by percentile

### DIFF
--- a/expertise/execute_expertise.py
+++ b/expertise/execute_expertise.py
@@ -82,7 +82,8 @@ def execute_expertise(config):
             specter_batch_size=config['model_params'].get('batch_size', 16),
             use_cuda=config['model_params'].get('use_cuda', False),
             sparse_value=config['model_params'].get('sparse_value'),
-            compute_paper_paper=config['model_params'].get('compute_paper_paper', False)
+            compute_paper_paper=config['model_params'].get('compute_paper_paper', False),
+            percentile_select=config['model_params'].get('percentile_select', 100)
         )
         ens_predictor.set_archives_dataset(archives_dataset)
         ens_predictor.set_submissions_dataset(submissions_dataset)
@@ -120,7 +121,8 @@ def execute_expertise(config):
             use_cuda=config['model_params'].get('use_cuda', False),
             sparse_value=config['model_params'].get('sparse_value'),
             dump_p2p=config['model_params'].get('dump_p2p', False),
-            compute_paper_paper=config['model_params'].get('compute_paper_paper', False)
+            compute_paper_paper=config['model_params'].get('compute_paper_paper', False),
+            percentile_select=config['model_params'].get('percentile_select', 100)
         )
         scincl_predictor.set_archives_dataset(archives_dataset)
         scincl_predictor.set_submissions_dataset(submissions_dataset)
@@ -154,7 +156,8 @@ def execute_expertise(config):
             use_cuda=config['model_params'].get('use_cuda', False),
             sparse_value=config['model_params'].get('sparse_value'),
             dump_p2p=config['model_params'].get('dump_p2p', False),
-            compute_paper_paper=config['model_params'].get('compute_paper_paper', False)
+            compute_paper_paper=config['model_params'].get('compute_paper_paper', False),
+            percentile_select=config['model_params'].get('percentile_select', 100)
         )
         spec2_predictor.set_archives_dataset(archives_dataset)
         spec2_predictor.set_submissions_dataset(submissions_dataset)

--- a/expertise/execute_expertise.py
+++ b/expertise/execute_expertise.py
@@ -83,7 +83,7 @@ def execute_expertise(config):
             use_cuda=config['model_params'].get('use_cuda', False),
             sparse_value=config['model_params'].get('sparse_value'),
             compute_paper_paper=config['model_params'].get('compute_paper_paper', False),
-            percentile_select=config['model_params'].get('percentile_select', 100)
+            percentile_select=config['model_params'].get('percentile_select', None)
         )
         ens_predictor.set_archives_dataset(archives_dataset)
         ens_predictor.set_submissions_dataset(submissions_dataset)
@@ -122,7 +122,7 @@ def execute_expertise(config):
             sparse_value=config['model_params'].get('sparse_value'),
             dump_p2p=config['model_params'].get('dump_p2p', False),
             compute_paper_paper=config['model_params'].get('compute_paper_paper', False),
-            percentile_select=config['model_params'].get('percentile_select', 100)
+            percentile_select=config['model_params'].get('percentile_select', None)
         )
         scincl_predictor.set_archives_dataset(archives_dataset)
         scincl_predictor.set_submissions_dataset(submissions_dataset)
@@ -157,7 +157,7 @@ def execute_expertise(config):
             sparse_value=config['model_params'].get('sparse_value'),
             dump_p2p=config['model_params'].get('dump_p2p', False),
             compute_paper_paper=config['model_params'].get('compute_paper_paper', False),
-            percentile_select=config['model_params'].get('percentile_select', 100)
+            percentile_select=config['model_params'].get('percentile_select', None)
         )
         spec2_predictor.set_archives_dataset(archives_dataset)
         spec2_predictor.set_submissions_dataset(submissions_dataset)

--- a/expertise/models/specter2_scincl/ensemble.py
+++ b/expertise/models/specter2_scincl/ensemble.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 class EnsembleModel:
     def __init__(self, specter_dir, work_dir,
                  average_score=False, max_score=True, specter_batch_size=16, merge_alpha=0.5,
-                 use_cuda=True, sparse_value=None, use_redis=False, compute_paper_paper=False):
+                 use_cuda=True, sparse_value=None, use_redis=False, compute_paper_paper=False, percentile_select=100):
         self.specter_predictor = Specter2Predictor(
             specter_dir=specter_dir,
             work_dir=os.path.join(work_dir, "specter"),
@@ -18,7 +18,8 @@ class EnsembleModel:
             use_cuda=use_cuda,
             sparse_value=sparse_value,
             use_redis=use_redis,
-            compute_paper_paper=compute_paper_paper
+            compute_paper_paper=compute_paper_paper,
+            percentile_select=percentile_select
         )
 
         self.scincl_predictor = SciNCLPredictor(
@@ -30,7 +31,8 @@ class EnsembleModel:
             use_cuda=use_cuda,
             sparse_value=sparse_value,
             use_redis=use_redis,
-            compute_paper_paper=compute_paper_paper
+            compute_paper_paper=compute_paper_paper,
+            percentile_select=percentile_select
         )
         self.merge_alpha = merge_alpha
         self.sparse_value = sparse_value

--- a/expertise/models/specter2_scincl/ensemble.py
+++ b/expertise/models/specter2_scincl/ensemble.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 class EnsembleModel:
     def __init__(self, specter_dir, work_dir,
                  average_score=False, max_score=True, specter_batch_size=16, merge_alpha=0.5,
-                 use_cuda=True, sparse_value=None, use_redis=False, compute_paper_paper=False, percentile_select=100):
+                 use_cuda=True, sparse_value=None, use_redis=False, compute_paper_paper=False, percentile_select=None):
         self.specter_predictor = Specter2Predictor(
             specter_dir=specter_dir,
             work_dir=os.path.join(work_dir, "specter"),

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -271,7 +271,6 @@ class SciNCLPredictor(Predictor):
                     # q=0.5 (percentile_select=50) -> median score
                     # q=0.0 (percentile_select=0) -> min score
                     q = self.percentile_select / 100.0
-                    # Ensure q is within [0, 1] - should be guaranteed by config validation, but belt-and-suspenders
                     q = max(0.0, min(1.0, q)) 
                     all_paper_aff = torch.quantile(train_paper_aff_j, q, dim=1, interpolation='linear')
                 elif self.average_score:

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -40,7 +40,7 @@ silent
 """
 class SciNCLPredictor(Predictor):
     def __init__(self, specter_dir, work_dir, average_score=False, max_score=True, batch_size=16, use_cuda=True,
-                 sparse_value=None, use_redis=False, dump_p2p=False, compute_paper_paper=False, percentile_select=100):
+                 sparse_value=None, use_redis=False, dump_p2p=False, compute_paper_paper=False, percentile_select=None):
         self.model_name = 'scincl'
         self.specter_dir = specter_dir
         self.model_archive_file = os.path.join(specter_dir, "model.tar.gz")

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -275,13 +275,13 @@ class Specter2Predictor(Predictor):
                     # q=0.5 (percentile_select=50) -> median score
                     # q=0.0 (percentile_select=0) -> min score
                     q = self.percentile_select / 100.0
-                    # Ensure q is within [0, 1] - should be guaranteed by config validation, but belt-and-suspenders
-                    q = max(0.0, min(1.0, q)) 
+                    q = max(0.0, min(1.0, q))
                     all_paper_aff = torch.quantile(train_paper_aff_j, q, dim=1, interpolation='linear')
                 elif self.average_score:
                     all_paper_aff = train_paper_aff_j.mean(dim=1)
                 elif self.max_score:
                     all_paper_aff = train_paper_aff_j.max(dim=1)[0]
+                for j in range(paper_num_test):
                     csv_line = '{note_id},{reviewer},{score}'.format(note_id=test_id_list[j], reviewer=reviewer_id,
                                                                     score=all_paper_aff[j].item())
                     csv_scores.append(csv_line)

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -41,7 +41,7 @@ silent
 """
 class Specter2Predictor(Predictor):
     def __init__(self, specter_dir, work_dir, average_score=False, max_score=True, batch_size=16, use_cuda=True,
-                 sparse_value=None, use_redis=False, dump_p2p=False, compute_paper_paper=False):
+                 sparse_value=None, use_redis=False, dump_p2p=False, compute_paper_paper=False, percentile_select=None):
         self.model_name = 'specter2'
         self.specter_dir = specter_dir
         self.model_archive_file = os.path.join(specter_dir, "model.tar.gz")
@@ -65,6 +65,7 @@ class Specter2Predictor(Predictor):
         self.dump_p2p = dump_p2p
         self.compute_paper_paper = compute_paper_paper
 
+        self.percentile_select = percentile_select
         self.tokenizer = AutoTokenizer.from_pretrained('allenai/specter2_aug2023refresh_base')
         #load base model
         self.model = AutoAdapterModel.from_pretrained('allenai/specter2_aug2023refresh_base')
@@ -268,11 +269,19 @@ class Specter2Predictor(Predictor):
                         train_paper_idx.append(paper_id2train_idx[paper_id])
                 train_paper_aff_j = p2p_aff_norm[:, train_paper_idx]
 
-                if self.average_score:
+                if self.percentile_select is not None:
+                    # Select score based on percentile
+                    # q=1.0 (percentile_select=100) -> max score
+                    # q=0.5 (percentile_select=50) -> median score
+                    # q=0.0 (percentile_select=0) -> min score
+                    q = self.percentile_select / 100.0
+                    # Ensure q is within [0, 1] - should be guaranteed by config validation, but belt-and-suspenders
+                    q = max(0.0, min(1.0, q)) 
+                    all_paper_aff = torch.quantile(train_paper_aff_j, q, dim=1, interpolation='linear')
+                elif self.average_score:
                     all_paper_aff = train_paper_aff_j.mean(dim=1)
                 elif self.max_score:
                     all_paper_aff = train_paper_aff_j.max(dim=1)[0]
-                for j in range(paper_num_test):
                     csv_line = '{note_id},{reviewer},{score}'.format(note_id=test_id_list[j], reviewer=reviewer_id,
                                                                     score=all_paper_aff[j].item())
                     csv_scores.append(csv_line)

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -499,7 +499,8 @@ class JobConfig(object):
             'useTitle',
             'useAbstract',
             'scoreComputation',
-            'skipSpecter'
+            'skipSpecter',
+            'percentileSelect'
         ]
         config.model = starting_config.get('model', None)
         model_params = starting_config.get('model_params', {})
@@ -514,7 +515,7 @@ class JobConfig(object):
         config.model_params['sparse_value'] = model_params.get('sparse_value', 300)
         config.model_params['use_cuda'] = model_params.get('use_cuda', False)
         config.model_params['use_redis'] = model_params.get('use_redis', False)
-
+        config.model_params['percentile_select'] = model_params.get('percentile_select', None)
         # Attempt to load any API request model params
         api_model = api_request.model
         if api_model:

--- a/tests/data/fakeData.json
+++ b/tests/data/fakeData.json
@@ -660,6 +660,14 @@
           "title": "Phys Rehab & Diag Audiology, Rehab, Vestib Trmt",
           "abstract": "Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.\n\nPraesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede."
         }
+      },
+      {
+        "id": "jPWcSSFH",
+        "cdate": 1584038279,
+        "content": {
+          "title": "Unsupervised Domain Adaptation through Shape Modeling for Medical Image Segments",
+          "abstract": "Shape information is a strong and valuable prior in segmenting organs in medical images. However, most current deep learning based segmentation algorithms have not taken shape information into consideration, which can lead to bias towards texture. We aim at modeling shape explicitly and using it to help medical image segmentation. Previous methods proposed Variational Autoencoder (VAE) based models to learn the distribution of shape for a particular organ and used it to automatically evaluate the quality of a segmentation prediction by fitting it into the learned shape distribution. Based on which we aim at incorporating VAE into current segmentation pipelines. Specifically, we propose a new unsupervised domain adaptation pipeline based on a pseudo loss and a VAE reconstruction loss under a teacher-student learning paradigm. Both losses are optimized simultaneously and, in return, boost the segmentation task performance. Extensive experiments on three public Pancreas segmentation datasets as well as two in-house Pancreas segmentation datasets show consistent improvements with at least 2.8 points gain in the Dice score, demonstrating the effectiveness of our method in challenging unsupervised domain adaptation scenarios for medical image segmentation. We hope this work will advance shape analysis and geometric learning in medical imaging."
+        }
       }
     ]
   }, {

--- a/tests/test_create_conference.py
+++ b/tests/test_create_conference.py
@@ -86,7 +86,15 @@ class TestConference():
                 'Expected Submissions': '100',
                 'include_expertise_selection': 'Yes',
                 'submission_reviewer_assignment': 'Automatic',
-                'submission_license': ['CC BY-SA 4.0']
+                'submission_license': ['CC BY-SA 4.0'],
+                'venue_organizer_agreement': [
+                    'OpenReview natively supports a wide variety of reviewing workflow configurations. However, if we want significant reviewing process customizations or experiments, we will detail these requests to the OpenReview staff at least three months in advance.',
+                    'We will ask authors and reviewers to create an OpenReview Profile at least two weeks in advance of the paper submission deadlines.',
+                    'When assembling our group of reviewers and meta-reviewers, we will only include email addresses or OpenReview Profile IDs of people we know to have authored publications relevant to our venue.  (We will not solicit new reviewers using an open web form, because unfortunately some malicious actors sometimes try to create "fake ids" aiming to be assigned to review their own paper submissions.)',
+                    'We acknowledge that, if our venue\'s reviewing workflow is non-standard, or if our venue is expecting more than a few hundred submissions for any one deadline, we should designate our own Workflow Chair, who will read the OpenReview documentation and manage our workflow configurations throughout the reviewing process.',
+                    'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
+                    'We will treat the OpenReview staff with kindness and consideration.'
+                ]
             }))
 
         helpers.await_queue()
@@ -153,7 +161,15 @@ class TestConference():
                 'How did you hear about us?': 'ML conferences',
                 'Expected Submissions': '100',
                 'submission_reviewer_assignment': 'Automatic',
-                'submission_license': ['CC BY-SA 4.0']
+                'submission_license': ['CC BY-SA 4.0'],
+                'venue_organizer_agreement': [
+                    'OpenReview natively supports a wide variety of reviewing workflow configurations. However, if we want significant reviewing process customizations or experiments, we will detail these requests to the OpenReview staff at least three months in advance.',
+                    'We will ask authors and reviewers to create an OpenReview Profile at least two weeks in advance of the paper submission deadlines.',
+                    'When assembling our group of reviewers and meta-reviewers, we will only include email addresses or OpenReview Profile IDs of people we know to have authored publications relevant to our venue.  (We will not solicit new reviewers using an open web form, because unfortunately some malicious actors sometimes try to create "fake ids" aiming to be assigned to review their own paper submissions.)',
+                    'We acknowledge that, if our venue\'s reviewing workflow is non-standard, or if our venue is expecting more than a few hundred submissions for any one deadline, we should designate our own Workflow Chair, who will read the OpenReview documentation and manage our workflow configurations throughout the reviewing process.',
+                    'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
+                    'We will treat the OpenReview staff with kindness and consideration.'
+                ]
             }))
 
         helpers.await_queue()
@@ -220,7 +236,15 @@ class TestConference():
                 'Expected Submissions': '100',
                 'include_expertise_selection': 'Yes',
                 'submission_reviewer_assignment': 'Automatic',
-                'submission_license': ['CC BY-SA 4.0']
+                'submission_license': ['CC BY-SA 4.0'],
+                'venue_organizer_agreement': [
+                    'OpenReview natively supports a wide variety of reviewing workflow configurations. However, if we want significant reviewing process customizations or experiments, we will detail these requests to the OpenReview staff at least three months in advance.',
+                    'We will ask authors and reviewers to create an OpenReview Profile at least two weeks in advance of the paper submission deadlines.',
+                    'When assembling our group of reviewers and meta-reviewers, we will only include email addresses or OpenReview Profile IDs of people we know to have authored publications relevant to our venue.  (We will not solicit new reviewers using an open web form, because unfortunately some malicious actors sometimes try to create "fake ids" aiming to be assigned to review their own paper submissions.)',
+                    'We acknowledge that, if our venue\'s reviewing workflow is non-standard, or if our venue is expecting more than a few hundred submissions for any one deadline, we should designate our own Workflow Chair, who will read the OpenReview documentation and manage our workflow configurations throughout the reviewing process.',
+                    'We acknowledge that OpenReview staff work Monday-Friday during standard business hours US Eastern time, and we cannot expect support responses outside those times.  For this reason, we recommend setting submission and reviewing deadlines Monday through Thursday.',
+                    'We will treat the OpenReview staff with kindness and consideration.'
+                ]
             }))
 
         helpers.await_queue()

--- a/tests/test_create_dataset.py
+++ b/tests/test_create_dataset.py
@@ -15,7 +15,7 @@ def test_convert_to_list(client, openreview_client):
 def test_get_papers_from_group(client, openreview_client):
     or_expertise = OpenReviewExpertise(client, openreview_client, {})
     all_papers = or_expertise.get_papers_from_group('DEF.cc/Reviewers')
-    assert len(all_papers) == 146
+    assert len(all_papers) == 147
     if os.path.isfile('publications_by_profile_id.json'):
         os.remove('publications_by_profile_id.json')
 

--- a/tests/test_expertise_apiv2.py
+++ b/tests/test_expertise_apiv2.py
@@ -239,11 +239,11 @@ class TestExpertiseV2():
                         'id': target_id
                     },
                     "model": {
-                            "name": "specter+mfr",
+                            "name": "specter2+scincl",
                             'useTitle': False, 
                             'useAbstract': True, 
                             'skipSpecter': False,
-                            'scoreComputation': 'avg'
+                            'scoreComputation': 'max'
                     }
                 }
             ),
@@ -312,6 +312,7 @@ class TestExpertiseV2():
         assert metadata['submission_count'] == 1
         response = response.json['results']
         medical_score, translation_score = 0, 0
+        target_id = None
         for item in response:
             print(item)
             submission_id, profile_id, score = item['submission'], item['user'], float(item['score'])
@@ -324,12 +325,158 @@ class TestExpertiseV2():
             if profile_id == '~Kyunghyun_Cho1':
                 translation_score = score
 
+            target_id = submission_id
+
         # Check for correctness
         assert medical_score > 0
         assert translation_score > 0
         assert medical_score > 0.5
         assert translation_score < 0.5
-        
+
+        ## This distribution is more spread out since Margherita
+        ## has a 2 papers: 1 with high score and 1 with low score
+        assert medical_score < 0.9
+
+
+        ## Repeat again with percentileSelect to lowest
+        MAX_TIMEOUT = 600 # Timeout after 10 minutes
+        # Make a request for TMLR/Reviewers
+        response = test_client.post(
+            '/expertise',
+            data = json.dumps({
+                    "name": "test_run",
+                    "entityA": {
+                        'type': "Group",
+                        'memberOf': "TMLR/Reviewers",
+                    },
+                    "entityB": { 
+                        'type': "Note",
+                        'id': target_id
+                    },
+                    "model": {
+                            "name": "specter2+scincl",
+                            'useTitle': False, 
+                            'useAbstract': True, 
+                            'skipSpecter': False,
+                            'percentileSelect': 0
+                    }
+                }
+            ),
+            content_type='application/json',
+            headers=openreview_client.headers
+        )
+        assert response.status_code == 200, f'{response.json}'
+        print(f"second request ret: {response.json}")
+        print(f"setting job_id to {response.json['jobId']}")
+        job_id = response.json['jobId']
+        time.sleep(2)
+        response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f'{job_id}'}).json
+        assert response['name'] == 'test_run'
+        assert response['status'] != 'Error'
+
+        # Query until job is complete
+        response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f'{job_id}'}).json
+        start_time = time.time()
+        try_time = time.time() - start_time
+        while response['status'] != 'Completed' and try_time <= MAX_TIMEOUT:
+            time.sleep(5)
+            response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f'{job_id}'}).json
+            if response['status'] == 'Error':
+                assert False, response[0]['description']
+            try_time = time.time() - start_time
+
+        assert try_time <= MAX_TIMEOUT, 'Job has not completed in time'
+        assert response['status'] == 'Completed'
+        assert response['name'] == 'test_run'
+        assert response['description'] == 'Job is complete and the computed scores are ready'
+
+        response = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': f"{job_id}"})
+        response = response.json['results']
+        for item in response:
+            print(item)
+            submission_id, profile_id, score = item['submission'], item['user'], float(item['score'])
+            assert len(submission_id) >= 1
+            assert len(profile_id) >= 1
+            assert profile_id.startswith('~')
+            assert score >= 0 and score <= 1
+            if profile_id == '~Raia_Hadsell1':
+                assert score > 0.95
+            if profile_id == '~Margherita_Hilpert1':
+                assert score < 0.05
+                ## This is very low because the user has lorem ipsum papers
+                ## and percentile selects lowest score
+
+                ## This distribution is more spread out since Margherita
+                ## has a 2 papers: 1 with high score and 1 with low score
+
+        ## Repeat again with percentileSelect to 50, should still be low
+        MAX_TIMEOUT = 600 # Timeout after 10 minutes
+        # Make a request for TMLR/Reviewers
+        response = test_client.post(
+            '/expertise',
+            data = json.dumps({
+                    "name": "test_run",
+                    "entityA": {
+                        'type': "Group",
+                        'memberOf': "TMLR/Reviewers",
+                    },
+                    "entityB": { 
+                        'type': "Note",
+                        'id': target_id
+                    },
+                    "model": {
+                            "name": "specter2+scincl",
+                            'useTitle': False, 
+                            'useAbstract': True, 
+                            'skipSpecter': False,
+                            'percentileSelect': 0
+                    }
+                }
+            ),
+            content_type='application/json',
+            headers=openreview_client.headers
+        )
+        assert response.status_code == 200, f'{response.json}'
+        print(f"second request ret: {response.json}")
+        print(f"setting job_id to {response.json['jobId']}")
+        job_id = response.json['jobId']
+        time.sleep(2)
+        response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f'{job_id}'}).json
+        assert response['name'] == 'test_run'
+        assert response['status'] != 'Error'
+
+        # Query until job is complete
+        response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f'{job_id}'}).json
+        start_time = time.time()
+        try_time = time.time() - start_time
+        while response['status'] != 'Completed' and try_time <= MAX_TIMEOUT:
+            time.sleep(5)
+            response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f'{job_id}'}).json
+            if response['status'] == 'Error':
+                assert False, response[0]['description']
+            try_time = time.time() - start_time
+
+        assert try_time <= MAX_TIMEOUT, 'Job has not completed in time'
+        assert response['status'] == 'Completed'
+        assert response['name'] == 'test_run'
+        assert response['description'] == 'Job is complete and the computed scores are ready'
+
+        response = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': f"{job_id}"})
+        response = response.json['results']
+        for item in response:
+            print(item)
+            submission_id, profile_id, score = item['submission'], item['user'], float(item['score'])
+            assert len(submission_id) >= 1
+            assert len(profile_id) >= 1
+            assert profile_id.startswith('~')
+            assert score >= 0 and score <= 1
+            if profile_id == '~Raia_Hadsell1':
+                assert score > 0.95
+            if profile_id == '~Margherita_Hilpert1':
+                assert score < 0.05
+                ## This is very low because the user has lorem ipsum papers
+                ## and percentile selects lowest score
+
         # Clean up journal request
         response = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': f"{openreview_context['job_id']}", 'deleteOnGet': True}).json['results']
         assert not os.path.isdir(f"./tests/jobs/{openreview_context['job_id']}")


### PR DESCRIPTION
Resolves #232 

This PR adds a new config and API parameter that allows the venue to select which part of a reviewer's publication history should be used based on affinity score.

The new parameter in the API request is at the `model.percentile_select` level, or the `model_params.percentile_select` level.

A value of 100 will use the score of the most similar publication as the affinity score and a value of 0 will use the least similar publication as the affinity score for a user.