### PR TITLE
Feature: Increase Machine Size

### DIFF
--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -28,6 +28,15 @@ DEFAULT_CONFIG = {
 DELETED_FIELDS = ['user_id', 'cdate']
 
 def run_pipeline(api_request_str, working_dir=None):
+    # Try parsing api_request_str as JSON, otherwise assume its a filepath
+    try:
+        raw_request: dict = json.loads(api_request_str)
+    except:
+        if not os.path.exists(api_request_str):
+            raise FileNotFoundError(f"File {api_request_str} not found")
+        with open(api_request_str, 'r') as f:
+            raw_request = json.load(f)
+        print(f"Loaded request from {api_request_str}")
 
     # Pop token, base URLs and other expected variable
     try:


### PR DESCRIPTION
This PR increases the size the machines running the expertise jobs to `n1-highmem-64` in order to support NeurIPS-sized venues.

The execute pipeline code now attempts to read either a JSON file or parse the argument as a JSON itself.

The build pipeline code needed to be migrated to `google-cloud-pipeline-components` to pass the `boot_disk_size_gb` argument. The migrated components cannot use raw JSON strings when passing between them because of unescaped quote problems so paths to a stored artifact in the bucket are used