### PR TITLE
Fix: Allow prefix/value not hosted on OpenReview

### DIFF
--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -98,11 +98,20 @@ class OpenReviewExpertise(object):
             ## Papers allowed: accepted papers from an OpenReview venue
             ## not in_openreview: DBLP papers (venueid =/= domain) and non-accepted papers (domain not in venue_list)
 
+            has_prefix_match = 'prefix' in venue_spec and venueid.startswith(venue_spec['prefix'])
+            has_exact_value_match = 'value' in venue_spec and venueid == venue_spec['value']
+            submitted_to_openreview = (
+                'articleSubmittedToOpenReview' in venue_spec and in_openreview and venue_spec['articleSubmittedToOpenReview']
+            )
+            not_submitted_to_openreview = (
+                'articleSubmittedToOpenReview' in venue_spec and not in_openreview and not venue_spec['articleSubmittedToOpenReview']
+            )
+            
             return (
-                ('prefix' in venue_spec and venueid.startswith(venue_spec['prefix'])) or
-                ('value' in venue_spec and venueid == venue_spec['value']) or
-                ('articleSubmittedToOpenReview' in venue_spec and in_openreview and venue_spec['articleSubmittedToOpenReview']) or
-                ('articleSubmittedToOpenReview' in venue_spec and not in_openreview and not venue_spec['articleSubmittedToOpenReview'])
+                has_prefix_match or
+                has_exact_value_match or
+                submitted_to_openreview or
+                not_submitted_to_openreview
             )
         
         # Get domain from either domain field or invitation prefix

--- a/expertise/create_dataset.py
+++ b/expertise/create_dataset.py
@@ -99,8 +99,8 @@ class OpenReviewExpertise(object):
             ## not in_openreview: DBLP papers (venueid =/= domain) and non-accepted papers (domain not in venue_list)
 
             return (
-                ('prefix' in venue_spec and in_openreview and venueid.startswith(venue_spec['prefix'])) or
-                ('value' in venue_spec and in_openreview and venueid == venue_spec['value']) or
+                ('prefix' in venue_spec and venueid.startswith(venue_spec['prefix'])) or
+                ('value' in venue_spec and venueid == venue_spec['value']) or
                 ('articleSubmittedToOpenReview' in venue_spec and in_openreview and venue_spec['articleSubmittedToOpenReview']) or
                 ('articleSubmittedToOpenReview' in venue_spec and not in_openreview and not venue_spec['articleSubmittedToOpenReview'])
             )

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -789,7 +789,7 @@ class GCPInterface(object):
         data['baseurl_v1'] = openreview.tools.get_base_urls(or_client)[0]
         data['baseurl_v2'] = openreview.tools.get_base_urls(or_client)[1]
         data['gcs_folder'] = f"gs://{self.bucket_name}/{folder_path}"
-        data['dump_embs'] = True
+        #data['dump_embs'] = True
         data['dump_archives'] = True
 
         # Deleted metadata fields before hitting the pipeline


### PR DESCRIPTION
This PR removes the check that the venueid of a publication is in the `venues` group for the `prefix` and `value` keywords, allowing them to target specific venues even if they are DBLP/Archive papers

---

This PR also enables uploading of archives folder and embedding files to GCS by default. Tests for this functionality already exist in `test_pipeline.py`

https://github.com/openreview/openreview-expertise/blob/c73d4641a687abcb670942f22bb07586daa9e7b3/tests/test_pipeline.py#L126-L134

The lines that are uncommented add the `dump_embs` and `dump_archives` keywords to the JSON that gets passed to the pipeline, which is tested here:
https://github.com/openreview/openreview-expertise/blob/c73d4641a687abcb670942f22bb07586daa9e7b3/tests/test_pipeline.py#L53-L77