### PR TITLE
Fix: Upload archives

### DIFF
--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -789,8 +789,8 @@ class GCPInterface(object):
         data['baseurl_v1'] = openreview.tools.get_base_urls(or_client)[0]
         data['baseurl_v2'] = openreview.tools.get_base_urls(or_client)[1]
         data['gcs_folder'] = f"gs://{self.bucket_name}/{folder_path}"
-        #data['dump_embs'] = True
-        #data['dump_archives'] = True
+        data['dump_embs'] = True
+        data['dump_archives'] = True
 
         # Deleted metadata fields before hitting the pipeline
         data['user_id'] = user_id if user_id else get_user_id(or_client)


### PR DESCRIPTION
Enables uploading of archives folder and embedding files to GCS by default. Tests for this functionality already exist in `test_pipeline.py`

https://github.com/openreview/openreview-expertise/blob/c73d4641a687abcb670942f22bb07586daa9e7b3/tests/test_pipeline.py#L126-L134

The lines that are uncommented add the `dump_embs` and `dump_archives` keywords to the JSON that gets passed to the pipeline, which is tested here:
https://github.com/openreview/openreview-expertise/blob/c73d4641a687abcb670942f22bb07586daa9e7b3/tests/test_pipeline.py#L53-L77