### PR TITLE
Feature: Allow disable normalization

### DIFF
--- a/expertise/execute_expertise.py
+++ b/expertise/execute_expertise.py
@@ -85,7 +85,8 @@ def execute_expertise(config):
             sparse_value=config['model_params'].get('sparse_value'),
             compute_paper_paper=config['model_params'].get('compute_paper_paper', False),
             venue_specific_weights=venue_specific_weights,
-            percentile_select=config['model_params'].get('percentile_select', None)
+            percentile_select=config['model_params'].get('percentile_select', None),
+            normalize_scores=config['model_params'].get('normalize_scores', True)
         )
         ens_predictor.set_archives_dataset(archives_dataset)
         ens_predictor.set_submissions_dataset(submissions_dataset)
@@ -124,7 +125,8 @@ def execute_expertise(config):
             sparse_value=config['model_params'].get('sparse_value'),
             dump_p2p=config['model_params'].get('dump_p2p', False),
             compute_paper_paper=config['model_params'].get('compute_paper_paper', False),
-            percentile_select=config['model_params'].get('percentile_select', None)
+            percentile_select=config['model_params'].get('percentile_select', None),
+            normalize_scores=config['model_params'].get('normalize_scores', True)
         )
         scincl_predictor.set_archives_dataset(archives_dataset)
         scincl_predictor.set_submissions_dataset(submissions_dataset)
@@ -159,7 +161,8 @@ def execute_expertise(config):
             sparse_value=config['model_params'].get('sparse_value'),
             dump_p2p=config['model_params'].get('dump_p2p', False),
             compute_paper_paper=config['model_params'].get('compute_paper_paper', False),
-            percentile_select=config['model_params'].get('percentile_select', None)
+            percentile_select=config['model_params'].get('percentile_select', None),
+            normalize_scores=config['model_params'].get('normalize_scores', True)
         )
         spec2_predictor.set_archives_dataset(archives_dataset)
         spec2_predictor.set_submissions_dataset(submissions_dataset)

--- a/expertise/models/specter2_scincl/ensemble.py
+++ b/expertise/models/specter2_scincl/ensemble.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 class EnsembleModel:
     def __init__(self, specter_dir, work_dir,
                  average_score=False, max_score=True, specter_batch_size=16, merge_alpha=0.5,
-                 use_cuda=True, sparse_value=None, use_redis=False, compute_paper_paper=False, percentile_select=None, venue_specific_weights=None):
+                 use_cuda=True, sparse_value=None, use_redis=False, compute_paper_paper=False, percentile_select=None, venue_specific_weights=None, normalize_scores=True):
         self.specter_predictor = Specter2Predictor(
             specter_dir=specter_dir,
             work_dir=os.path.join(work_dir, "specter"),
@@ -20,7 +20,8 @@ class EnsembleModel:
             use_redis=use_redis,
             compute_paper_paper=compute_paper_paper,
             venue_specific_weights=venue_specific_weights,
-            percentile_select=percentile_select
+            percentile_select=percentile_select,
+            normalize_scores=normalize_scores
         )
 
         self.scincl_predictor = SciNCLPredictor(
@@ -34,7 +35,8 @@ class EnsembleModel:
             use_redis=use_redis,
             compute_paper_paper=compute_paper_paper,
             venue_specific_weights=venue_specific_weights,
-            percentile_select=percentile_select
+            percentile_select=percentile_select,
+            normalize_scores=normalize_scores
         )
         self.merge_alpha = merge_alpha
         self.sparse_value = sparse_value

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -40,7 +40,8 @@ silent
 """
 class SciNCLPredictor(Predictor):
     def __init__(self, specter_dir, work_dir, average_score=False, max_score=True, batch_size=16, use_cuda=True,
-                 sparse_value=None, use_redis=False, dump_p2p=False, compute_paper_paper=False, percentile_select=None, venue_specific_weights=False):
+                 sparse_value=None, use_redis=False, dump_p2p=False, compute_paper_paper=False, percentile_select=None, venue_specific_weights=False,
+                 normalize_scores=True):
         self.model_name = 'scincl'
         self.specter_dir = specter_dir
         self.model_archive_file = os.path.join(specter_dir, "model.tar.gz")
@@ -64,6 +65,7 @@ class SciNCLPredictor(Predictor):
         self.dump_p2p = dump_p2p
         self.compute_paper_paper = compute_paper_paper
         self.venue_specific_weights = venue_specific_weights
+        self.normalize_scores = normalize_scores
         print(f"SciNCL venue_specific_weights: {venue_specific_weights}")
         self.percentile_select = percentile_select
 
@@ -252,9 +254,14 @@ class SciNCLPredictor(Predictor):
                 json.dump(p2p_dict, f, indent=4)
 
         # Normalize all scores
-        min_val = p2p_aff.min()
-        max_val = p2p_aff.max()
-        p2p_aff_norm = (p2p_aff - min_val) / (max_val - min_val)
+        if self.normalize_scores:
+            print("Normalizing scores...")
+            min_val = p2p_aff.min()
+            max_val = p2p_aff.max()
+            p2p_aff_norm = (p2p_aff - min_val) / (max_val - min_val)
+        else:
+            print("Skipping normalization of scores...")
+            p2p_aff_norm = p2p_aff
 
         csv_scores = []
         self.preliminary_scores = []

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -41,7 +41,8 @@ silent
 """
 class Specter2Predictor(Predictor):
     def __init__(self, specter_dir, work_dir, average_score=False, max_score=True, batch_size=16, use_cuda=True,
-                 sparse_value=None, use_redis=False, dump_p2p=False, compute_paper_paper=False, percentile_select=None, venue_specific_weights=None):
+                 sparse_value=None, use_redis=False, dump_p2p=False, compute_paper_paper=False, percentile_select=None, venue_specific_weights=None,
+                 normalize_scores=True):
         self.model_name = 'specter2'
         self.specter_dir = specter_dir
         self.model_archive_file = os.path.join(specter_dir, "model.tar.gz")
@@ -65,6 +66,7 @@ class Specter2Predictor(Predictor):
         self.dump_p2p = dump_p2p
         self.compute_paper_paper = compute_paper_paper
         self.venue_specific_weights = venue_specific_weights
+        self.normalize_scores = normalize_scores
         print(f"SPECTER2 venue_specific_weights: {venue_specific_weights}")
 
         self.percentile_select = percentile_select
@@ -255,9 +257,14 @@ class Specter2Predictor(Predictor):
                 json.dump(p2p_dict, f, indent=4)
         
         # Normalize all scores
-        min_val = p2p_aff.min()
-        max_val = p2p_aff.max()
-        p2p_aff_norm = (p2p_aff - min_val) / (max_val - min_val)
+        if self.normalize_scores:
+            print("Normalizing scores...")
+            min_val = p2p_aff.min()
+            max_val = p2p_aff.max()
+            p2p_aff_norm = (p2p_aff - min_val) / (max_val - min_val)
+        else:
+            print("Skipping normalization of scores...")
+            p2p_aff_norm = p2p_aff
 
         csv_scores = []
         self.preliminary_scores = []

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -10,6 +10,39 @@ from expertise.dataset import ArchivesDataset, SubmissionsDataset
 from expertise.models import specter2_scincl
 import redisai
 
+
+def compute_score_statistics(scores, label=""):
+    """Compute histogram-like statistics for affinity scores."""
+    score_values = [float(row[2]) for row in scores]
+    stats = {
+        'count': len(score_values),
+        'mean': np.mean(score_values),
+        'std': np.std(score_values),
+        'min': np.min(score_values),
+        'max': np.max(score_values),
+        'median': np.median(score_values),
+        'q25': np.percentile(score_values, 25),
+        'q75': np.percentile(score_values, 75),
+    }
+    
+    # Histogram bins
+    hist, bin_edges = np.histogram(score_values, bins=10)
+    
+    print(f"\n=== Score Statistics {label} ===")
+    print(f"Count: {stats['count']}")
+    print(f"Mean: {stats['mean']:.4f}")
+    print(f"Std: {stats['std']:.4f}")
+    print(f"Min: {stats['min']:.4f}")
+    print(f"Max: {stats['max']:.4f}")
+    print(f"Median: {stats['median']:.4f}")
+    print(f"Q25: {stats['q25']:.4f}")
+    print(f"Q75: {stats['q75']:.4f}")
+    print("\nHistogram:")
+    for i in range(len(hist)):
+        print(f"  [{bin_edges[i]:.3f}, {bin_edges[i+1]:.3f}): {hist[i]} ({hist[i]/len(score_values)*100:.1f}%)")
+    
+    return stats
+
 @pytest.fixture
 def create_specncl():
     def simple_specncl(config):
@@ -24,7 +57,8 @@ def create_specncl():
             specter_batch_size=config['model_params'].get('specter_batch_size', 16),
             use_cuda=config['model_params'].get('use_cuda', False),
             sparse_value=config['model_params'].get('sparse_value'),
-            use_redis=config['model_params'].get('use_redis', False)
+            use_redis=config['model_params'].get('use_redis', False),
+            normalize_scores=config['model_params'].get('normalize_scores', True),
         )
 
         ens_predictor.set_archives_dataset(archives_dataset)
@@ -125,3 +159,119 @@ def test_sparse_scores(tmp_path, create_specncl):
         assert len(profile_id) >= 1
         assert profile_id.startswith('~')
         assert score >= 0 and score <= 1
+
+def test_normalization(tmp_path, create_specncl):
+    # Test unnormalized scores
+    unnorm_path = tmp_path / '-unnorm'
+    config = {
+        'name': 'test_specncl_unnormalized',
+        'model_params': {
+            'use_title': True,
+            'use_abstract': True,
+            'use_cuda': False,
+            'batch_size': 1,
+            'average_score': True,
+            'max_score': False,
+            'sparse_value': 1,
+            'work_dir': unnorm_path,
+            'normalize_scores': False
+        }
+    }
+
+    specnclModel = create_specncl(config)
+
+    publications_path = unnorm_path / 'publications'
+    publications_path.mkdir()
+    submissions_path = unnorm_path / 'submissions'
+    submissions_path.mkdir()
+    specnclModel.embed_publications(
+        specter_publications_path=publications_path.joinpath('pub2vec_specter.jsonl'),
+        scincl_publications_path=publications_path.joinpath('pub2vec_scincl.jsonl')
+    )
+    specnclModel.embed_submissions(
+        specter_submissions_path=submissions_path.joinpath('sub2vec_specter.jsonl'),
+        scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.jsonl'),
+    )
+
+    scores_path = unnorm_path / 'scores'
+    scores_path.mkdir()
+    all_scores = specnclModel.all_scores(
+        specter_publications_path=publications_path.joinpath('pub2vec_specter.jsonl'),
+        scincl_publications_path=publications_path.joinpath('pub2vec_scincl.jsonl'),
+        specter_submissions_path=submissions_path.joinpath('sub2vec_specter.jsonl'),
+        scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.jsonl'),
+        scores_path=scores_path.joinpath(config['name'] + '.csv')
+    )
+
+    for row in all_scores:
+        submission_id, profile_id, score = row[0], row[1], float(row[2])
+        assert len(submission_id) >= 1
+        assert len(profile_id) >= 1
+        assert profile_id.startswith('~')
+        assert score >= 0 and score <= 1
+    
+    # Compute statistics for unnormalized scores
+    unnorm_stats = compute_score_statistics(all_scores, "(Unnormalized)")
+    
+    # Test normalization
+    norm_path = tmp_path / '-norm'
+    config = {
+        'name': 'test_specncl_normalized',
+        'model_params': {
+            'use_title': True,
+            'use_abstract': True,
+            'use_cuda': False,
+            'batch_size': 1,
+            'average_score': True,
+            'max_score': False,
+            'sparse_value': 1,
+            'work_dir': norm_path
+        }
+    }
+
+    specnclModel = create_specncl(config)
+
+    publications_path = norm_path / 'publications'
+    publications_path.mkdir()
+    submissions_path = norm_path / 'submissions'
+    submissions_path.mkdir()
+    specnclModel.embed_publications(
+        specter_publications_path=publications_path.joinpath('pub2vec_specter.jsonl'),
+        scincl_publications_path=publications_path.joinpath('pub2vec_scincl.jsonl')
+    )
+    specnclModel.embed_submissions(
+        specter_submissions_path=submissions_path.joinpath('sub2vec_specter.jsonl'),
+        scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.jsonl'),
+    )
+
+    scores_path = norm_path / 'scores'
+    scores_path.mkdir()
+    all_scores = specnclModel.all_scores(
+        specter_publications_path=publications_path.joinpath('pub2vec_specter.jsonl'),
+        scincl_publications_path=publications_path.joinpath('pub2vec_scincl.jsonl'),
+        specter_submissions_path=submissions_path.joinpath('sub2vec_specter.jsonl'),
+        scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.jsonl'),
+        scores_path=scores_path.joinpath(config['name'] + '.csv')
+    )
+
+    for row in all_scores:
+        submission_id, profile_id, score = row[0], row[1], float(row[2])
+        assert len(submission_id) >= 1
+        assert len(profile_id) >= 1
+        assert profile_id.startswith('~')
+        assert score >= 0 and score <= 1    
+    # Compute statistics for normalized scores
+    norm_stats = compute_score_statistics(all_scores, "(Normalized)")
+
+    # Unnormalized mean tends to be around 0.8
+    # Normalization by definition should be closer to 0.5
+    assert norm_stats['mean'] < unnorm_stats['mean']
+
+    ## Perform epsilon neighborhood check
+    epsilon = 0.05  # Define a small epsilon value for neighborhood check
+    assert abs(norm_stats['mean'] - 0.5) < epsilon, f"Normalized mean {norm_stats['mean']} is not within epsilon neighborhood of 0.5"
+    assert abs(unnorm_stats['mean'] - 0.8) < epsilon, f"Unnormalized mean {unnorm_stats['mean']} is not within epsilon neighborhood of 0.8"
+
+    # Unnormalized std should be smaller than normalized std
+    ## Unnormalized scores tend to be more concentrated and higher
+    assert unnorm_stats['std'] < norm_stats['std'], f"Unnormalized std {unnorm_stats['std']} should be less than normalized std {norm_stats['std']}"


### PR DESCRIPTION
This PR adds a new flag `normalize_scores` to the `model_params` field of the config file that allows the user to skip the normalization across all computed scores.

The default behavior is to normalize scores in order preserve the current functionality