### PR TITLE
Fix: Refactor pipeline config

### DIFF
--- a/expertise/build_pipeline.py
+++ b/expertise/build_pipeline.py
@@ -5,7 +5,6 @@ from kfp.dsl import (
     component,
     container_component,
     InputPath,
-    OutputPath,
     ContainerSpec
 )
 from kfp.registry import RegistryClient
@@ -74,24 +73,15 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
-    # New component to write a string (our JSON config) to a file
-    @component(base_image='python:3.9-slim')
-    def write_string_to_file_op(
-        data: str,
-        output_file: OutputPath(str)
-    ):
-        """Writes string data to a file."""
-        with open(output_file, 'w') as f:
-            f.write(data)
 
     @component(
         base_image=f"{args.region}-docker.pkg.dev/{args.project}/{args.repo}/{args.image}:{args.tag}"
     )
     def execute_expertise_pipeline_op(
-        job_config_file: str
+        gcs_request_path: str
     ) -> None:
         from expertise.execute_pipeline import run_pipeline
-        run_pipeline(job_config_file)
+        run_pipeline(gcs_request_path)
 
     custom_expertise_job_from_file_input = create_custom_training_job_from_component(
         execute_expertise_pipeline_op,
@@ -105,21 +95,16 @@ if __name__ == '__main__':
 
     @pipeline(
         name=args.kfp_name,
-        description='Processes request for user-paper expertise scores using file-based config'
+        description='Processes request for user-paper expertise scores using GCS path'
     )
     def expertise_pipeline(
-        job_config: str
+        gcs_request_path: str
     ):
-        # Write the raw JSON string to a file
-        write_config_task = write_string_to_file_op(
-            data=job_config
-        ).set_display_name("Write Job Config to File")
-
-        # Pass the path to this file to the custom job
+        # Pass the GCS path directly to the custom job
         run_expertise_task = custom_expertise_job_from_file_input(
             project=args.project,
             location=args.kfp_region,
-            job_config_file=write_config_task.outputs['output_file'] # Pass the output file path
+            gcs_request_path=gcs_request_path
         ).set_display_name("Running Expertise Pipeline")
 
     compiler.Compiler().compile(

--- a/expertise/build_pipeline.py
+++ b/expertise/build_pipeline.py
@@ -81,7 +81,9 @@ if __name__ == '__main__':
         gcs_request_path: str
     ) -> None:
         from expertise.execute_pipeline import run_pipeline
-        run_pipeline(gcs_request_path)
+        run_pipeline(
+            gcs_dir=gcs_request_path
+        )
 
     custom_expertise_job_from_file_input = create_custom_training_job_from_component(
         execute_expertise_pipeline_op,

--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -47,8 +47,7 @@ def download_from_gcs(gcs_path):
     # Parse GCS path: gs://bucket_name/path/to/file
     _, bucket = load_gcs(gcs_path)
 
-    blob_prefix = '/'.join(gcs_path.split('/')[3:])
-    blob_name = f"{blob_prefix}/request.json"
+    blob_name = '/'.join(gcs_path.split('/')[3:])
     
     blob = bucket.blob(blob_name)
     

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -798,12 +798,15 @@ class GCPInterface(object):
 
         write_json_to_gcs(self.bucket_name, folder_path, self.request_fname, data)
 
+        # Pass GCS path instead of JSON data to avoid parameter size limits
+        gcs_request_path = f"gs://{self.bucket_name}/{folder_path}/{self.request_fname}"
+
         job = aip.PipelineJob(
             display_name = valid_vertex_id,
             template_path = f"https://{self.region}-kfp.pkg.dev/{self.project_id}/{self.pipeline_repo}/{self.pipeline_name}/{self.pipeline_tag}",
             job_id = valid_vertex_id,
             pipeline_root = f"gs://{self.bucket_name}/{self.pipeline_root}",
-            parameter_values = {'job_config': json.dumps(data)},
+            parameter_values = {'gcs_request_path': gcs_request_path},
             labels = self.service_label)
 
         job.submit()

--- a/tests/test_gcp_interface.py
+++ b/tests/test_gcp_interface.py
@@ -159,7 +159,7 @@ def test_create_job(mock_storage_client, mock_pipeline_job, openreview_client):
         ),
         job_id=result,
         pipeline_root="gs://test-bucket/pipeline-root",
-        parameter_values={"job_config": json.dumps(submitted_json)},
+        parameter_values={"gcs_request_path": f"gs://test-bucket/{expected_folder_path}/request.json"},
         labels={"test": "label"}
     )
     mock_pipeline_instance.submit.assert_called_once()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -100,7 +100,7 @@ def test_run_pipeline(mock_load_model_artifacts, mock_execute_expertise, openrev
 
     # Call the function
     from expertise.execute_pipeline import run_pipeline  # Replace with the actual module path
-    run_pipeline(api_request_str, working_dir)
+    run_pipeline(api_request_str=api_request_str, working_dir=working_dir)
 
     # Assertions
 
@@ -192,7 +192,7 @@ def test_run_pipeline_group(mock_load_model_artifacts, mock_execute_expertise, o
 
     # Call the function
     from expertise.execute_pipeline import run_pipeline  # Replace with the actual module path
-    run_pipeline(api_request_str, working_dir)
+    run_pipeline(api_request_str=api_request_str, working_dir=working_dir)
 
     # Assertions
     bucket = gcs_test_bucket
@@ -275,7 +275,7 @@ def test_run_pipeline_paper_paper(mock_load_model_artifacts, mock_execute_expert
 
     # Call the function
     from expertise.execute_pipeline import run_pipeline  # Replace with the actual module path
-    run_pipeline(api_request_str, working_dir)
+    run_pipeline(api_request_str=api_request_str, working_dir=working_dir)
 
     # Assertions
     # Check that blobs were created and data was uploaded to GCS
@@ -355,7 +355,7 @@ def test_runtime_errors(mock_load_model_artifacts, mock_execute_expertise, openr
     # Call the function
     from expertise.execute_pipeline import run_pipeline  # Replace with the actual module path
     try:
-        run_pipeline(api_request_str, working_dir)
+        run_pipeline(api_request_str=api_request_str, working_dir=working_dir)
     except Exception as e:
         assert str(e) == 'Not Found Error: No papers found for: invitation_ids: [\'PIPELINE_ERR.cc/-/Submission\']'
 


### PR DESCRIPTION
This PR replaces how we pass the API request from the API to Vertex AI.

Previously, we would pass the entire request as a JSON string in the parameters, but this isn't scalable when passing raw submission data in the request (title + abstract).

The approach now just reads the `request.json` in the function that gets executed by Vertex AI, and the pipeline gets the path of the request file