### PR TITLE
Fix: Allow passing withContent with value none

### DIFF
--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -233,9 +233,9 @@ class APIRequest(object):
                         all_values.append('venueid')
                     else:
                         return 'venueid'
-            if 'withContent' in entity and return_as_list:
+            if 'withContent' in entity and entity.get('withContent') and return_as_list:
                 if get_value:
-                    for key, value in entity['withContent'].items():
+                    for key, value in entity.get('withContent', {}).items():
                         all_values.append(f"{key}:{value}")
                 elif get_prefix:
                     all_values.append('withContent')

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -567,7 +567,7 @@ class TestExpertiseService():
                     },
                     "entityB": { 
                         'type': "Note",
-                        'invitation': "ABC.cc/-/Submission" 
+                        'invitation': "ABC.cc/-/Submission"
                     },
                     "model": {
                             "name": "specter2+scincl",
@@ -651,7 +651,8 @@ class TestExpertiseService():
                     },
                     "entityB": { 
                         'type': "Note",
-                        'invitation': "ABC.cc/-/Submission" 
+                        'invitation': "ABC.cc/-/Submission",
+                        'withContent': None
                     },
                     "model": {
                             "name": "specter2+scincl",


### PR DESCRIPTION
This PR fixes an issues where `withContent: None` was failing by trying to treat None as a dictionary. This PR adds an extra check for none and falls back to an empty dict to avoid breaking the iteration