### PR TITLE
Fix: Prevent Vertex AI pipeline jobs from hanging on HuggingFace downloads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,25 @@ jobs:
             python -m pip install -e .
             python -m pip install -I protobuf==3.20.1
       - run:
+          name: Pre-download HuggingFace models
+          command: |
+            source ~/miniconda/etc/profile.d/conda.sh
+            conda activate expertise
+            python -c "
+            from transformers import AutoTokenizer, AutoModel
+            AutoTokenizer.from_pretrained('allenai/specter')
+            AutoModel.from_pretrained('allenai/specter')
+            AutoTokenizer.from_pretrained('allenai/specter2_aug2023refresh_base')
+            AutoModel.from_pretrained('allenai/specter2_aug2023refresh_base')
+            AutoTokenizer.from_pretrained('malteos/scincl')
+            AutoModel.from_pretrained('malteos/scincl')
+            "
+            python -c "
+            from adapters import AutoAdapterModel
+            model = AutoAdapterModel.from_pretrained('allenai/specter2_aug2023refresh_base')
+            model.load_adapter('allenai/specter2_aug2023refresh', source='hf', load_as='proximity', set_active=True)
+            "
+      - run:
           name: Initialize MongoDB
           command: |
             docker run -d --name mongodb -p 27017:27017 mongo:8.0 --replSet rs0

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 ENV PYTHON_VERSION=3.11 \
     HOME="/app" \
+    PYTHONUNBUFFERED=1 \
     PATH="/app/miniconda/bin:${PATH}" \
     AIP_STORAGE_URI="gs://openreview-expertise/expertise-utils/" \
     SPECTER_DIR="/app/expertise-utils/specter/" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Add conda environment bin to PATH so that 'python' uses the environment by default
 ENV PATH="/app/miniconda/envs/expertise/bin:${PATH}"
 
+# Pre-download HuggingFace models so jobs don't depend on HF availability at runtime
+RUN python -c "\
+from transformers import AutoTokenizer, AutoModel; \
+AutoTokenizer.from_pretrained('allenai/specter'); \
+AutoModel.from_pretrained('allenai/specter'); \
+AutoTokenizer.from_pretrained('allenai/specter2_aug2023refresh_base'); \
+AutoModel.from_pretrained('allenai/specter2_aug2023refresh_base'); \
+AutoTokenizer.from_pretrained('malteos/scincl'); \
+AutoModel.from_pretrained('malteos/scincl'); \
+" && python -c "\
+from adapters import AutoAdapterModel; \
+model = AutoAdapterModel.from_pretrained('allenai/specter2_aug2023refresh_base'); \
+model.load_adapter('allenai/specter2_aug2023refresh', source='hf', load_as='proximity', set_active=True); \
+"
+
 RUN mkdir ${HOME}/expertise-utils \
     && cp ${HOME}/openreview-expertise/expertise/service/config/default_container.cfg \
        ${HOME}/openreview-expertise/expertise/service/config/production.cfg

--- a/expertise/dataset/core.py
+++ b/expertise/dataset/core.py
@@ -36,7 +36,7 @@ class ArchivesDataset(UserDict):
     This class maps a tilde id to its list of publications
     '''
     def __init__(self, **kwargs):
-        print('Loading Archives dataset...')
+        print('Loading Archives dataset...', flush=True)
         if kwargs.get('archives_path'):
             author_archives = defaultdict(list)
             for author_file in Path(kwargs['archives_path']).iterdir():
@@ -69,7 +69,7 @@ class SubmissionsDataset(UserDict):
     This class maps a Note id to its Note
     '''
     def __init__(self, **kwargs):
-        print('Loading Submissions dataset...')
+        print('Loading Submissions dataset...', flush=True)
         if kwargs.get('submissions_path'):
             submissions = {}
             for submission_file in Path(kwargs['submissions_path']).iterdir():

--- a/expertise/execute_expertise.py
+++ b/expertise/execute_expertise.py
@@ -64,7 +64,9 @@ def execute_expertise(config):
         )
 
     if config['model'] == 'specter2+scincl':
+        print("Importing specter2_scincl module...", flush=True)
         from .models import specter2_scincl
+        print("Module imported, creating EnsembleModel...", flush=True)
         predictor = specter2_scincl.EnsembleModel(
             specter_dir=config['model_params'].get('specter_dir', "./models/multifacet_recommender/specter/"),
             work_dir=config['model_params'].get('work_dir', "./"),

--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -1,5 +1,11 @@
 import argparse
 import os
+
+# Set HuggingFace timeouts (in seconds) before importing any model code.
+# Prevents jobs from hanging indefinitely if HuggingFace Hub is unreachable.
+os.environ.setdefault('HF_HUB_DOWNLOAD_TIMEOUT', '600')
+os.environ.setdefault('HF_HUB_ETAG_TIMEOUT', '30')
+
 import openreview
 import shortuuid
 import json

--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -108,12 +108,8 @@ def run_pipeline(
         _, bucket = load_gcs(destination_prefix)
         blob_prefix = '/'.join(destination_prefix.split('/')[3:])
 
-        model_type = raw_request.get('model', DEFAULT_CONFIG['model'])
-        if model_type in ('specter+mfr', 'specter', 'mfr'):
-            print(f'Loading model artifacts for {model_type}')
-            load_model_artifacts()
-        else:
-            print(f'Skipping GCS artifact download for {model_type}')
+        print('Loading model artifacts')
+        load_model_artifacts()
 
         print('Logging into OpenReview')
         client_v2 = openreview.api.OpenReviewClient(baseurl_v2, token=token)

--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -114,8 +114,12 @@ def run_pipeline(
         _, bucket = load_gcs(destination_prefix)
         blob_prefix = '/'.join(destination_prefix.split('/')[3:])
 
-        print('Loading model artifacts')
-        load_model_artifacts()
+        model_type = raw_request.get('model', DEFAULT_CONFIG['model'])
+        if model_type in ('specter+mfr', 'specter', 'mfr'):
+            print(f'Loading model artifacts for {model_type}')
+            load_model_artifacts()
+        else:
+            print(f'Skipping GCS artifact download for {model_type}')
 
         print('Logging into OpenReview')
         client_v2 = openreview.api.OpenReviewClient(baseurl_v2, token=token)

--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -1,11 +1,5 @@
 import argparse
 import os
-
-# Set HuggingFace timeouts (in seconds) before importing any model code.
-# Prevents jobs from hanging indefinitely if HuggingFace Hub is unreachable.
-os.environ.setdefault('HF_HUB_DOWNLOAD_TIMEOUT', '600')
-os.environ.setdefault('HF_HUB_ETAG_TIMEOUT', '30')
-
 import openreview
 import shortuuid
 import json

--- a/expertise/models/multifacet_recommender/specter.py
+++ b/expertise/models/multifacet_recommender/specter.py
@@ -21,8 +21,6 @@ from typing import Optional
 import redisai
 import numpy as np
 
-from expertise.service.server import redis_embeddings_pool
-
 import logging
 
 """
@@ -69,6 +67,7 @@ class SpecterPredictor:
             os.makedirs(self.work_dir)
         self.use_redis = use_redis
         if use_redis:
+            from expertise.service.server import redis_embeddings_pool
             self.redis = redisai.Client(connection_pool=redis_embeddings_pool)
         else:
             self.redis = None

--- a/expertise/models/multifacet_recommender/specter.py
+++ b/expertise/models/multifacet_recommender/specter.py
@@ -74,9 +74,11 @@ class SpecterPredictor:
             self.redis = None
         self.compute_paper_paper = compute_paper_paper
 
+        print("Loading tokenizer 'allenai/specter'...")
         self.tokenizer = AutoTokenizer.from_pretrained('allenai/specter')
-        #load base model
+        print("Loading model 'allenai/specter'...")
         self.model = AutoModel.from_pretrained('allenai/specter')
+        print("Model loaded, moving to device...")
         self.model.to(self.cuda_device)
         self.model.eval()
 

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -69,9 +69,11 @@ class SciNCLPredictor(Predictor):
         print(f"SciNCL venue_specific_weights: {venue_specific_weights}")
         self.percentile_select = percentile_select
 
+        print("Loading tokenizer 'malteos/scincl'...")
         self.tokenizer = AutoTokenizer.from_pretrained('malteos/scincl')
-        #load base model
+        print("Loading model 'malteos/scincl'...")
         self.model = AutoModel.from_pretrained('malteos/scincl')
+        print("Model loaded, moving to device...")
         self.model.to(self.cuda_device)
         self.model.eval()
 

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -14,8 +14,6 @@ import numpy as np
 from transformers import AutoTokenizer, AutoModel
 from .predictor import Predictor
 
-from expertise.service.server import redis_embeddings_pool
-
 import logging
 """
 archive_file: $SPECTER_FOLDER/model.tar.gz

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -66,14 +66,14 @@ class Specter2Predictor(Predictor):
         self.compute_paper_paper = compute_paper_paper
         self.venue_specific_weights = venue_specific_weights
         self.normalize_scores = normalize_scores
-        print(f"SPECTER2 venue_specific_weights: {venue_specific_weights}")
+        print(f"SPECTER2 venue_specific_weights: {venue_specific_weights}", flush=True)
 
         self.percentile_select = percentile_select
-        print("Loading tokenizer 'allenai/specter2_aug2023refresh_base'...")
+        print("Loading tokenizer 'allenai/specter2_aug2023refresh_base'...", flush=True)
         self.tokenizer = AutoTokenizer.from_pretrained('allenai/specter2_aug2023refresh_base')
-        print("Loading model 'allenai/specter2_aug2023refresh_base'...")
+        print("Loading model 'allenai/specter2_aug2023refresh_base'...", flush=True)
         self.model = AutoAdapterModel.from_pretrained('allenai/specter2_aug2023refresh_base')
-        print("Loading adapter 'allenai/specter2_aug2023refresh'...")
+        print("Loading adapter 'allenai/specter2_aug2023refresh'...", flush=True)
         adapter_timeout = int(os.environ.get('HF_HUB_DOWNLOAD_TIMEOUT', 600))
         with ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -70,11 +70,13 @@ class Specter2Predictor(Predictor):
         print(f"SPECTER2 venue_specific_weights: {venue_specific_weights}")
 
         self.percentile_select = percentile_select
+        print("Loading tokenizer 'allenai/specter2_aug2023refresh_base'...")
         self.tokenizer = AutoTokenizer.from_pretrained('allenai/specter2_aug2023refresh_base')
-        #load base model
+        print("Loading model 'allenai/specter2_aug2023refresh_base'...")
         self.model = AutoAdapterModel.from_pretrained('allenai/specter2_aug2023refresh_base')
-        #load the adapter(s) as per the required task, provide an identifier for the adapter in load_as argument and activate it
+        print("Loading adapter 'allenai/specter2_aug2023refresh'...")
         self.model.load_adapter("allenai/specter2_aug2023refresh", source="hf", load_as="proximity", set_active=True)
+        print("Model loaded, moving to device...")
         self.model.to(self.cuda_device)
         self.model.eval()
 

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -16,8 +16,6 @@ from transformers import AutoTokenizer, AutoModel
 from adapters import AutoAdapterModel
 from .predictor import Predictor
 
-from expertise.service.server import redis_embeddings_pool
-
 import logging
 """
 archive_file: $SPECTER_FOLDER/model.tar.gz

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -1,7 +1,6 @@
 import time
 
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 import json
 import os
 import torch
@@ -74,24 +73,8 @@ class Specter2Predictor(Predictor):
         print("Loading model 'allenai/specter2_aug2023refresh_base'...", flush=True)
         self.model = AutoAdapterModel.from_pretrained('allenai/specter2_aug2023refresh_base')
         print("Loading adapter 'allenai/specter2_aug2023refresh'...", flush=True)
-        adapter_timeout = int(os.environ.get('HF_HUB_DOWNLOAD_TIMEOUT', 600))
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(
-                self.model.load_adapter,
-                "allenai/specter2_aug2023refresh",
-                source="hf",
-                load_as="proximity",
-                set_active=True,
-            )
-            try:
-                future.result(timeout=adapter_timeout)
-            except FuturesTimeoutError:
-                future.cancel()
-                raise TimeoutError(
-                    f"Loading adapter 'allenai/specter2_aug2023refresh' timed out after {adapter_timeout}s. "
-                    "HuggingFace Hub may be unreachable."
-                )
-        print("Adapter loaded, moving to device...")
+        self.model.load_adapter("allenai/specter2_aug2023refresh", source="hf", load_as="proximity", set_active=True)
+        print("Model loaded, moving to device...", flush=True)
         self.model.to(self.cuda_device)
         self.model.eval()
 

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -1,6 +1,7 @@
 import time
 
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 import json
 import os
 import torch
@@ -75,8 +76,24 @@ class Specter2Predictor(Predictor):
         print("Loading model 'allenai/specter2_aug2023refresh_base'...")
         self.model = AutoAdapterModel.from_pretrained('allenai/specter2_aug2023refresh_base')
         print("Loading adapter 'allenai/specter2_aug2023refresh'...")
-        self.model.load_adapter("allenai/specter2_aug2023refresh", source="hf", load_as="proximity", set_active=True)
-        print("Model loaded, moving to device...")
+        adapter_timeout = int(os.environ.get('HF_HUB_DOWNLOAD_TIMEOUT', 600))
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(
+                self.model.load_adapter,
+                "allenai/specter2_aug2023refresh",
+                source="hf",
+                load_as="proximity",
+                set_active=True,
+            )
+            try:
+                future.result(timeout=adapter_timeout)
+            except FuturesTimeoutError:
+                future.cancel()
+                raise TimeoutError(
+                    f"Loading adapter 'allenai/specter2_aug2023refresh' timed out after {adapter_timeout}s. "
+                    "HuggingFace Hub may be unreachable."
+                )
+        print("Adapter loaded, moving to device...")
         self.model.to(self.cuda_device)
         self.model.eval()
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='openreview-expertise',
-    version='2.1.0',
+    version='2.1.1',
     description='OpenReview paper-reviewer affinity modeling',
     url='https://github.com/openreview/openreview-expertise',
     author='OpenReview',


### PR DESCRIPTION
### Summary
- Pipeline jobs were intermittently hanging when Vertex AI workers couldn't reach HuggingFace Hub to download model weights at runtime
- Remove unnecessary `server.py` import from model files that triggered the entire Flask/BullMQ/GCP SDK stack during pipeline execution
- Pre-cache all HuggingFace models in the Docker image so jobs never depend on HuggingFace availability
- Skip GCS artifact download (`load_model_artifacts`) for models that don't need it (e.g. `specter2+scincl`)

### Changes

**Dockerfile**
- Add `PYTHONUNBUFFERED=1` for real-time log output in containers
- Pre-download all HuggingFace models (`allenai/specter`, `allenai/specter2_aug2023refresh_base`, `malteos/scincl`) and the specter2 adapter during image build

**expertise/models/\*/specter.py, scincl.py**
- Remove module-level `from expertise.service.server import redis_embeddings_pool` — this was unused in `specter2_scincl` and caused the entire web service stack (Flask, BullMQ, GCP AI Platform SDK) to initialize during pipeline jobs
- In `multifacet_recommender/specter.py`, the import is now lazy (only when `use_redis=True`)
- Add `print` statements with `flush=True` around model loading steps for better log visibility

**expertise/execute_pipeline.py**
- Skip `load_model_artifacts()` (GCS download) for models that don't use the old AllenNLP specter artifacts (e.g. `specter2+scincl`, `specter2`, `scincl`)

**expertise/execute_expertise.py**
- Add logging around model module import and initialization

**expertise/dataset/core.py**
- Add `flush=True` to dataset loading prints

### Root cause
HuggingFace models were downloaded from the internet on every pipeline job. When HuggingFace Hub was unreachable from certain Vertex AI workers, `AutoModel.from_pretrained()` and `load_adapter()` would hang indefinitely with no timeout or error. Additionally, importing `server.py` at module level caused the Flask app and all its dependencies to initialize unnecessarily during pipeline execution, which could also hang depending on the worker's network state.
