### PR TITLE
 Move HuggingFace models out of the Docker image and into GCS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,31 +88,39 @@ jobs:
             conda install "pytorch>=2.3" pytorch-cuda=12.4 -c pytorch -c nvidia
             conda install -y filelock
             conda install -y intel-openmp==2019.4
-            wget https://storage.googleapis.com/openreview-public/openreview-expertise/models-data/multifacet_recommender_data.tar.gz -O mfr.tar.gz
-            tar -xzvf mfr.tar.gz
-            mv ./multifacet_recommender_data ./multifacet_recommender
             cd ~/openreview-expertise
             python -m pip install -e .
             python -m pip install -I protobuf==3.20.1
       - run:
-          name: Pre-download HuggingFace models
+          name: Download model artifacts from GCS bucket
+          # Mirror the bucket path that Vertex AI pipeline workers use, so
+          # `test_specter2scincl.py` / `test_spectermfr.py` exercise the same
+          # code path in production (bucket -> local dir -> from_pretrained).
+          # Covers MFR + all HuggingFace snapshots so nothing falls back to HF.
           command: |
             source ~/miniconda/etc/profile.d/conda.sh
             conda activate expertise
+            cd ~/openreview-expertise
+            export AIP_STORAGE_URI="gs://openreview-expertise/expertise-utils/"
+            export EXPERTISE_UTILS_DIR="$HOME/expertise-utils"
             python -c "
-            from transformers import AutoTokenizer, AutoModel
-            AutoTokenizer.from_pretrained('allenai/specter')
-            AutoModel.from_pretrained('allenai/specter')
-            AutoTokenizer.from_pretrained('allenai/specter2_aug2023refresh_base')
-            AutoModel.from_pretrained('allenai/specter2_aug2023refresh_base')
-            AutoTokenizer.from_pretrained('malteos/scincl')
-            AutoModel.from_pretrained('malteos/scincl')
+            from expertise.service import load_model_artifacts
+            load_model_artifacts(subdirs=[
+                'multifacet_recommender',
+                'hf_models/specter',
+                'hf_models/specter2_base',
+                'hf_models/specter2_adapter',
+                'hf_models/scincl',
+            ])
             "
-            python -c "
-            from adapters import AutoAdapterModel
-            model = AutoAdapterModel.from_pretrained('allenai/specter2_aug2023refresh_base')
-            model.load_adapter('allenai/specter2_aug2023refresh', source='hf', load_as='proximity', set_active=True)
-            "
+            # Persist env vars for the test step so predictors pick up the
+            # local dirs instead of falling back to HuggingFace Hub.
+            {
+              echo "export SPECTER_HF_DIR=$HOME/expertise-utils/hf_models/specter"
+              echo "export SPECTER2_HF_DIR=$HOME/expertise-utils/hf_models/specter2_base"
+              echo "export SPECTER2_ADAPTER_DIR=$HOME/expertise-utils/hf_models/specter2_adapter"
+              echo "export SCINCL_HF_DIR=$HOME/expertise-utils/hf_models/scincl"
+            } >> "$BASH_ENV"
       - run:
           name: Initialize MongoDB
           command: |
@@ -223,7 +231,9 @@ jobs:
               -e "GOOGLE_APPLICATION_CREDENTIALS" \
               --entrypoint="" \
               expertise-test:${CIRCLE_SHA1:0:12} \
-              sh -c "cd /app/openreview-expertise && python -m pytest tests/test_pipeline.py tests/test_specter2scincl.py -v --tb=short"
+              sh -c "cd /app/openreview-expertise && \
+                     python -c 'from expertise.service import load_model_artifacts; load_model_artifacts(subdirs=[\"multifacet_recommender\", \"hf_models/specter\", \"hf_models/specter2_base\", \"hf_models/specter2_adapter\", \"hf_models/scincl\"])' && \
+                     python -m pytest tests/test_pipeline.py tests/test_specter2scincl.py -v --tb=short"
       - run:
           name: Copy API logs to artifacts
           when: on_fail

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,11 @@ ENV PYTHON_VERSION=3.11 \
     AIP_STORAGE_URI="gs://openreview-expertise/expertise-utils/" \
     SPECTER_DIR="/app/expertise-utils/specter/" \
     MFR_VOCAB_DIR="/app/expertise-utils/multifacet_recommender/feature_vocab_file" \
-    MFR_CHECKPOINT_DIR="/app/expertise-utils/multifacet_recommender/mfr_model_checkpoint/"
+    MFR_CHECKPOINT_DIR="/app/expertise-utils/multifacet_recommender/mfr_model_checkpoint/" \
+    SPECTER_HF_DIR="/app/expertise-utils/hf_models/specter" \
+    SPECTER2_HF_DIR="/app/expertise-utils/hf_models/specter2_base" \
+    SPECTER2_ADAPTER_DIR="/app/expertise-utils/hf_models/specter2_adapter" \
+    SCINCL_HF_DIR="/app/expertise-utils/hf_models/scincl"
 
 COPY . /app/openreview-expertise
 
@@ -43,20 +47,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Add conda environment bin to PATH so that 'python' uses the environment by default
 ENV PATH="/app/miniconda/envs/expertise/bin:${PATH}"
 
-# Pre-download HuggingFace models so jobs don't depend on HF availability at runtime
-RUN python -c "\
-from transformers import AutoTokenizer, AutoModel; \
-AutoTokenizer.from_pretrained('allenai/specter'); \
-AutoModel.from_pretrained('allenai/specter'); \
-AutoTokenizer.from_pretrained('allenai/specter2_aug2023refresh_base'); \
-AutoModel.from_pretrained('allenai/specter2_aug2023refresh_base'); \
-AutoTokenizer.from_pretrained('malteos/scincl'); \
-AutoModel.from_pretrained('malteos/scincl'); \
-" && python -c "\
-from adapters import AutoAdapterModel; \
-model = AutoAdapterModel.from_pretrained('allenai/specter2_aug2023refresh_base'); \
-model.load_adapter('allenai/specter2_aug2023refresh', source='hf', load_as='proximity', set_active=True); \
-"
+# HuggingFace models (specter, specter2 base + adapter, scincl) are not baked into
+# the image — they are fetched from gs://openreview-expertise/expertise-utils/hf_models/
+# at job start, selectively per-request, by expertise.service.load_model_artifacts.
 
 RUN mkdir ${HOME}/expertise-utils \
     && cp ${HOME}/openreview-expertise/expertise/service/config/default_container.cfg \

--- a/README.md
+++ b/README.md
@@ -540,6 +540,49 @@ Running the openreview-expertise test suite requires some initial setup. First, 
 - [OpenReview API](https://github.com/openreview/openreview-api)
 - [OpenReview API2](https://github.com/openreview/openreview-api-v1)
 
+### Download model artifacts
+
+The predictors load their weights from a local directory tree. The tests expect this tree at `../expertise-utils/` (relative to the repo), matching the layout used in production.
+
+**Recommended — from the OpenReview GCS bucket.** This is the same path that CI and the Vertex AI pipeline workers use, so running tests this way exercises the production code path. You need `gcloud` installed and read access to `gs://openreview-expertise/`:
+
+```bash
+gcloud auth application-default login
+
+export AIP_STORAGE_URI="gs://openreview-expertise/expertise-utils/"
+export EXPERTISE_UTILS_DIR="$(pwd)/../expertise-utils"
+
+python -c "
+from expertise.service import load_model_artifacts
+load_model_artifacts(subdirs=[
+    'multifacet_recommender',
+    'hf_models/specter',
+    'hf_models/specter2_base',
+    'hf_models/specter2_adapter',
+    'hf_models/scincl',
+])
+"
+```
+
+Then export the paths the predictors look for:
+
+```bash
+export SPECTER_HF_DIR="$(pwd)/../expertise-utils/hf_models/specter"
+export SPECTER2_HF_DIR="$(pwd)/../expertise-utils/hf_models/specter2_base"
+export SPECTER2_ADAPTER_DIR="$(pwd)/../expertise-utils/hf_models/specter2_adapter"
+export SCINCL_HF_DIR="$(pwd)/../expertise-utils/hf_models/scincl"
+```
+
+You'll see `[source=BUCKET (local dir)]` in the test output, confirming the predictors are loading from the bucket-mirrored tree rather than from HuggingFace.
+
+**Fallback — from HuggingFace Hub (no bucket access).** If you don't have access to the GCS bucket, leave `SPECTER_HF_DIR`, `SPECTER2_HF_DIR`, `SPECTER2_ADAPTER_DIR`, and `SCINCL_HF_DIR` unset. The predictors fall back to the HuggingFace Hub IDs (`allenai/specter`, `allenai/specter2_aug2023refresh_base`, `allenai/specter2_aug2023refresh`, `malteos/scincl`) and download them on first use. You'll see `[source=HUGGINGFACE HUB (network)]` in the logs.
+
+**Caveat:** `tests/test_spectermfr.py` cannot run this way because the MFR checkpoint only lives in the OpenReview GCS bucket — it is not published to HuggingFace. Skip that file if you don't have bucket access:
+
+```bash
+pytest tests --ignore=tests/test_spectermfr.py
+```
+
 Run Tests
 ---------
 

--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -5,7 +5,7 @@ import shortuuid
 import json
 import csv
 from expertise.execute_expertise import execute_create_dataset, execute_expertise
-from expertise.service import load_model_artifacts
+from expertise.service import load_model_artifacts, artifacts_for_model
 from expertise.service.utils import APIRequest, JobConfig, ExpectedDataError
 from expertise.utils.utils import generate_job_id
 from google.cloud import storage
@@ -108,8 +108,12 @@ def run_pipeline(
         _, bucket = load_gcs(destination_prefix)
         blob_prefix = '/'.join(destination_prefix.split('/')[3:])
 
-        print('Loading model artifacts')
-        load_model_artifacts()
+        # Download only the artifacts required for this model — a pipeline worker
+        # handles a single job and pulling unused models wastes startup time.
+        requested_model = raw_request.get('model', {}).get('name', DEFAULT_CONFIG['model'])
+        required_artifacts = artifacts_for_model(requested_model)
+        print(f'Loading model artifacts for model={requested_model}: {required_artifacts}')
+        load_model_artifacts(subdirs=required_artifacts)
 
         print('Logging into OpenReview')
         client_v2 = openreview.api.OpenReviewClient(baseurl_v2, token=token)

--- a/expertise/models/multifacet_recommender/ensemble.py
+++ b/expertise/models/multifacet_recommender/ensemble.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 class EnsembleModel:
     def __init__(self, specter_dir, mfr_feature_vocab_file, mfr_checkpoint_dir, mfr_epochs, work_dir,
                  average_score=False, max_score=True, specter_batch_size=16, mfr_batch_size=50, merge_alpha=0.8,
-                 use_cuda=True, sparse_value=None, use_redis=False):
+                 use_cuda=True, sparse_value=None, use_redis=False, specter_hf_dir=None):
         self.specter_predictor = SpecterPredictor(
             specter_dir=specter_dir,
             work_dir=os.path.join(work_dir, "specter"),
@@ -17,7 +17,8 @@ class EnsembleModel:
             batch_size=specter_batch_size,
             use_cuda=use_cuda,
             sparse_value=sparse_value,
-            use_redis=use_redis
+            use_redis=use_redis,
+            specter_hf_dir=specter_hf_dir
         )
 
         self.mfr_predictor = MultiFacetRecommender(

--- a/expertise/models/multifacet_recommender/specter.py
+++ b/expertise/models/multifacet_recommender/specter.py
@@ -47,10 +47,11 @@ silent
 
 class SpecterPredictor:
     def __init__(self, specter_dir, work_dir, average_score=False, max_score=True, batch_size=16, use_cuda=True,
-                 sparse_value=None, use_redis=False, compute_paper_paper=False):
+                 sparse_value=None, use_redis=False, compute_paper_paper=False, specter_hf_dir=None):
         self.specter_dir = specter_dir
         self.model_archive_file = os.path.join(specter_dir, "model.tar.gz")
         self.vocab_dir = os.path.join(specter_dir, "data/vocab/")
+        self.specter_hf_dir = specter_hf_dir or os.getenv('SPECTER_HF_DIR') or 'allenai/specter'
         self.predictor_name = "specter_predictor"
         self.work_dir = work_dir
         self.average_score = average_score
@@ -73,10 +74,11 @@ class SpecterPredictor:
             self.redis = None
         self.compute_paper_paper = compute_paper_paper
 
-        print("Loading tokenizer 'allenai/specter'...")
-        self.tokenizer = AutoTokenizer.from_pretrained('allenai/specter')
-        print("Loading model 'allenai/specter'...")
-        self.model = AutoModel.from_pretrained('allenai/specter')
+        specter_source = "BUCKET (local dir)" if os.path.isdir(self.specter_hf_dir) else "HUGGINGFACE HUB (network)"
+        print(f"[specter] Loading tokenizer from '{self.specter_hf_dir}' [source={specter_source}]", flush=True)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.specter_hf_dir)
+        print(f"[specter] Loading model from '{self.specter_hf_dir}' [source={specter_source}]", flush=True)
+        self.model = AutoModel.from_pretrained(self.specter_hf_dir)
         print("Model loaded, moving to device...")
         self.model.to(self.cuda_device)
         self.model.eval()

--- a/expertise/models/specter2_scincl/ensemble.py
+++ b/expertise/models/specter2_scincl/ensemble.py
@@ -8,7 +8,8 @@ from tqdm import tqdm
 class EnsembleModel:
     def __init__(self, specter_dir, work_dir,
                  average_score=False, max_score=True, specter_batch_size=16, merge_alpha=0.5,
-                 use_cuda=True, sparse_value=None, use_redis=False, compute_paper_paper=False, percentile_select=None, venue_specific_weights=None, normalize_scores=True):
+                 use_cuda=True, sparse_value=None, use_redis=False, compute_paper_paper=False, percentile_select=None, venue_specific_weights=None, normalize_scores=True,
+                 specter2_hf_dir=None, specter2_adapter_dir=None, scincl_hf_dir=None):
         self.specter_predictor = Specter2Predictor(
             specter_dir=specter_dir,
             work_dir=os.path.join(work_dir, "specter"),
@@ -21,7 +22,9 @@ class EnsembleModel:
             compute_paper_paper=compute_paper_paper,
             venue_specific_weights=venue_specific_weights,
             percentile_select=percentile_select,
-            normalize_scores=normalize_scores
+            normalize_scores=normalize_scores,
+            specter2_hf_dir=specter2_hf_dir,
+            specter2_adapter_dir=specter2_adapter_dir
         )
 
         self.scincl_predictor = SciNCLPredictor(
@@ -36,7 +39,8 @@ class EnsembleModel:
             compute_paper_paper=compute_paper_paper,
             venue_specific_weights=venue_specific_weights,
             percentile_select=percentile_select,
-            normalize_scores=normalize_scores
+            normalize_scores=normalize_scores,
+            scincl_hf_dir=scincl_hf_dir
         )
         self.merge_alpha = merge_alpha
         self.sparse_value = sparse_value

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -39,11 +39,12 @@ silent
 class SciNCLPredictor(Predictor):
     def __init__(self, specter_dir, work_dir, average_score=False, max_score=True, batch_size=16, use_cuda=True,
                  sparse_value=None, use_redis=False, dump_p2p=False, compute_paper_paper=False, percentile_select=None, venue_specific_weights=False,
-                 normalize_scores=True):
+                 normalize_scores=True, scincl_hf_dir=None):
         self.model_name = 'scincl'
         self.specter_dir = specter_dir
         self.model_archive_file = os.path.join(specter_dir, "model.tar.gz")
         self.vocab_dir = os.path.join(specter_dir, "data/vocab/")
+        self.scincl_hf_dir = scincl_hf_dir or os.getenv('SCINCL_HF_DIR') or 'malteos/scincl'
         self.predictor_name = "specter_predictor"
         self.work_dir = work_dir
         self.average_score = average_score
@@ -67,10 +68,11 @@ class SciNCLPredictor(Predictor):
         print(f"SciNCL venue_specific_weights: {venue_specific_weights}")
         self.percentile_select = percentile_select
 
-        print("Loading tokenizer 'malteos/scincl'...")
-        self.tokenizer = AutoTokenizer.from_pretrained('malteos/scincl')
-        print("Loading model 'malteos/scincl'...")
-        self.model = AutoModel.from_pretrained('malteos/scincl')
+        scincl_source = "BUCKET (local dir)" if os.path.isdir(self.scincl_hf_dir) else "HUGGINGFACE HUB (network)"
+        print(f"[scincl] Loading tokenizer from '{self.scincl_hf_dir}' [source={scincl_source}]", flush=True)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.scincl_hf_dir)
+        print(f"[scincl] Loading model from '{self.scincl_hf_dir}' [source={scincl_source}]", flush=True)
+        self.model = AutoModel.from_pretrained(self.scincl_hf_dir)
         print("Model loaded, moving to device...")
         self.model.to(self.cuda_device)
         self.model.eval()

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -40,11 +40,16 @@ silent
 class Specter2Predictor(Predictor):
     def __init__(self, specter_dir, work_dir, average_score=False, max_score=True, batch_size=16, use_cuda=True,
                  sparse_value=None, use_redis=False, dump_p2p=False, compute_paper_paper=False, percentile_select=None, venue_specific_weights=None,
-                 normalize_scores=True):
+                 normalize_scores=True, specter2_hf_dir=None, specter2_adapter_dir=None):
         self.model_name = 'specter2'
         self.specter_dir = specter_dir
         self.model_archive_file = os.path.join(specter_dir, "model.tar.gz")
         self.vocab_dir = os.path.join(specter_dir, "data/vocab/")
+        # Paths to locally-mirrored HuggingFace snapshots. Fall back to env vars
+        # (set in the container) and finally to the HF hub IDs so local dev can
+        # still download from HF if no mirror is available.
+        self.specter2_hf_dir = specter2_hf_dir or os.getenv('SPECTER2_HF_DIR') or 'allenai/specter2_aug2023refresh_base'
+        self.specter2_adapter_dir = specter2_adapter_dir or os.getenv('SPECTER2_ADAPTER_DIR') or 'allenai/specter2_aug2023refresh'
         self.predictor_name = "specter_predictor"
         self.work_dir = work_dir
         self.average_score = average_score
@@ -68,12 +73,19 @@ class Specter2Predictor(Predictor):
         print(f"SPECTER2 venue_specific_weights: {venue_specific_weights}", flush=True)
 
         self.percentile_select = percentile_select
-        print("Loading tokenizer 'allenai/specter2_aug2023refresh_base'...", flush=True)
-        self.tokenizer = AutoTokenizer.from_pretrained('allenai/specter2_aug2023refresh_base')
-        print("Loading model 'allenai/specter2_aug2023refresh_base'...", flush=True)
-        self.model = AutoAdapterModel.from_pretrained('allenai/specter2_aug2023refresh_base')
-        print("Loading adapter 'allenai/specter2_aug2023refresh'...", flush=True)
-        self.model.load_adapter("allenai/specter2_aug2023refresh", source="hf", load_as="proximity", set_active=True)
+        # `from_pretrained` and `load_adapter` accept a local directory as-is;
+        # when pointed at a HF hub ID they fall back to the network.
+        base_is_local = os.path.isdir(self.specter2_hf_dir)
+        adapter_is_local = os.path.isdir(self.specter2_adapter_dir)
+        base_source = "BUCKET (local dir)" if base_is_local else "HUGGINGFACE HUB (network)"
+        adapter_source_label = "BUCKET (local dir)" if adapter_is_local else "HUGGINGFACE HUB (network)"
+        adapter_source = "local" if adapter_is_local else "hf"
+        print(f"[specter2] Loading tokenizer from '{self.specter2_hf_dir}' [source={base_source}]", flush=True)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.specter2_hf_dir)
+        print(f"[specter2] Loading model from '{self.specter2_hf_dir}' [source={base_source}]", flush=True)
+        self.model = AutoAdapterModel.from_pretrained(self.specter2_hf_dir)
+        print(f"[specter2] Loading adapter from '{self.specter2_adapter_dir}' [source={adapter_source_label}]", flush=True)
+        self.model.load_adapter(self.specter2_adapter_dir, source=adapter_source, load_as="proximity", set_active=True)
         print("Model loaded, moving to device...", flush=True)
         self.model.to(self.cuda_device)
         self.model.eval()

--- a/expertise/service/__init__.py
+++ b/expertise/service/__init__.py
@@ -8,6 +8,34 @@ from google.cloud import storage
 artifact_loading_started = Event()
 model_ready = Event()
 
+# Maps an API `model` value to the GCS subdirectories (relative to AIP_STORAGE_URI)
+# that must be present on disk before the model can run. Subdirectories live under
+# `gs://<bucket>/<aip_prefix>/<subdir>/` and are mirrored to `/app/expertise-utils/<subdir>/`.
+MODEL_ARTIFACTS = {
+    'bm25': [],
+    'specter': ['hf_models/specter'],
+    'mfr': ['multifacet_recommender'],
+    'specter+mfr': ['hf_models/specter', 'multifacet_recommender'],
+    'specter2': ['hf_models/specter2_base', 'hf_models/specter2_adapter'],
+    'scincl': ['hf_models/scincl'],
+    'specter2+scincl': [
+        'hf_models/specter2_base',
+        'hf_models/specter2_adapter',
+        'hf_models/scincl',
+    ],
+}
+
+
+def artifacts_for_model(model):
+    """Return the list of GCS subdirectories required by `model`.
+
+    Unknown models fall back to downloading every artifact so the service keeps
+    working if a new model is introduced without updating this map.
+    """
+    if model in MODEL_ARTIFACTS:
+        return MODEL_ARTIFACTS[model]
+    return None
+
 def configure_logger(app):
     '''
     Configures the app's logger object.
@@ -94,8 +122,20 @@ def create_redis(app):
     )
     return config_pool, embedding_pool
 
-def load_model_artifacts():
-    """Copy all files from a GCS bucket directory to a local directory."""
+def load_model_artifacts(subdirs=None, destination_dir=None):
+    """Copy model artifacts from the GCS bucket to the local directory.
+
+    If `subdirs` is None, every file under AIP_STORAGE_URI is mirrored (used by
+    the long-lived Flask service). If `subdirs` is a list of subdirectory names,
+    only those subdirectories are downloaded (used by per-job pipeline workers
+    so they don't pull models they won't run).
+
+    An empty list downloads nothing — valid for the `bm25` model.
+
+    `destination_dir` defaults to env `EXPERTISE_UTILS_DIR` or `/app/expertise-utils`
+    (the container default). CI jobs running outside the container override it to
+    mirror into the CI workspace.
+    """
     artifact_loading_started.set()
 
     # Extract the bucket name and path from the environment variable
@@ -108,18 +148,43 @@ def load_model_artifacts():
     bucket_name = aip_storage_uri.split('/')[2]
     print(f"Bucket={bucket_name}")
 
-    # The directory to copy the artifacts to, and the subdirectory name you want
-    destination_dir = "/app/expertise-utils" ## TODO: Parameterize this
-    source_blob_prefix = '/'.join(aip_storage_uri.split('/')[3:])
+    if destination_dir is None:
+        destination_dir = os.getenv('EXPERTISE_UTILS_DIR', '/app/expertise-utils')
+    base_prefix = '/'.join(aip_storage_uri.split('/')[3:]).rstrip('/')
 
     storage_client = storage.Client()
     bucket = storage_client.bucket(bucket_name)
-    blobs = bucket.list_blobs(prefix=source_blob_prefix)
-    for blob in blobs:
-        destination_path = os.path.join(destination_dir, os.path.relpath(blob.name, start=source_blob_prefix))
-        os.makedirs(os.path.dirname(destination_path), exist_ok=True)
-        blob.download_to_filename(destination_path)
-        print(f"Copied {blob.name} to {destination_path}")
-    
-    print("Model artifacts loaded")
+
+    if subdirs is None:
+        print(f"[artifacts] Downloading ALL artifacts under gs://{bucket_name}/{base_prefix}/", flush=True)
+        prefixes = [base_prefix]
+    elif len(subdirs) == 0:
+        print("[artifacts] No artifacts required for this job, skipping GCS download.", flush=True)
+        model_ready.set()
+        return
+    else:
+        print(f"[artifacts] Selective download from gs://{bucket_name}/{base_prefix}/ — subdirs: {subdirs}", flush=True)
+        prefixes = [f"{base_prefix}/{s.strip('/')}" for s in subdirs]
+
+    total_files = 0
+    total_bytes = 0
+    for prefix in prefixes:
+        print(f"[artifacts] Downloading gs://{bucket_name}/{prefix}/", flush=True)
+        blobs = bucket.list_blobs(prefix=prefix + '/')
+        found = False
+        for blob in blobs:
+            found = True
+            destination_path = os.path.join(destination_dir, os.path.relpath(blob.name, start=base_prefix))
+            os.makedirs(os.path.dirname(destination_path), exist_ok=True)
+            blob.download_to_filename(destination_path)
+            total_files += 1
+            total_bytes += blob.size or 0
+            print(f"[artifacts] copied {blob.name} ({blob.size} bytes) -> {destination_path}", flush=True)
+        if not found:
+            raise FileNotFoundError(
+                f"No artifacts found at gs://{bucket_name}/{prefix}/ — "
+                f"check that the model files are uploaded to this location."
+            )
+
+    print(f"[artifacts] Done. Downloaded {total_files} files, {total_bytes / (1024*1024):.1f} MB from GCS bucket.", flush=True)
     model_ready.set()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -103,8 +103,18 @@ def test_run_pipeline(mock_load_model_artifacts, mock_execute_expertise, openrev
 
     # Assertions
 
+    # Pipeline worker pulled only the artifacts the requested model needs — read
+    # from raw_request['model']['name']. For 'specter+mfr': specter HF + MFR,
+    # and nothing from the specter2/scincl family.
+    mock_load_model_artifacts.assert_called_once()
+    downloaded_subdirs = mock_load_model_artifacts.call_args.kwargs['subdirs']
+    assert set(downloaded_subdirs) == {'hf_models/specter', 'multifacet_recommender'}
+    assert 'hf_models/specter2_base' not in downloaded_subdirs
+    assert 'hf_models/specter2_adapter' not in downloaded_subdirs
+    assert 'hf_models/scincl' not in downloaded_subdirs
+
     # Ensure execute_create_dataset and execute_expertise were called
-    # Use the gcs_test_bucket fixture to get actual 
+    # Use the gcs_test_bucket fixture to get actual
     bucket = gcs_test_bucket
     prefix = f"{gcs_jobs_prefix}/test_prefix/"
 
@@ -381,6 +391,18 @@ def test_run_pipeline_paper_paper(mock_load_model_artifacts, mock_execute_expert
     run_pipeline(api_request_str=api_request_str, working_dir=working_dir)
 
     # Assertions
+    # Pipeline worker pulled only the artifacts needed for 'specter2+scincl':
+    # specter2 base + adapter + scincl, and nothing MFR/legacy-specter related.
+    mock_load_model_artifacts.assert_called_once()
+    downloaded_subdirs = mock_load_model_artifacts.call_args.kwargs['subdirs']
+    assert set(downloaded_subdirs) == {
+        'hf_models/specter2_base',
+        'hf_models/specter2_adapter',
+        'hf_models/scincl',
+    }
+    assert 'hf_models/specter' not in downloaded_subdirs
+    assert 'multifacet_recommender' not in downloaded_subdirs
+
     # Check that blobs were created and data was uploaded to GCS
     bucket = gcs_test_bucket
     prefix = f"{gcs_jobs_prefix}/test_prefix_pap/"

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -45,6 +45,30 @@ def compute_score_statistics(scores, label=""):
     
     return stats
 
+def assert_scores_have_max_4_decimals(csv_path):
+    """Scores rounded to 4 decimals is a contract — CSVs exposed to the API
+    should never expose more precision than the model actually provides."""
+    violations = []
+    with open(csv_path) as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split(',')
+            if len(parts) < 3:
+                continue
+            score_str = parts[-1]
+            try:
+                float(score_str)
+            except ValueError:
+                continue
+            if '.' in score_str:
+                decimals = len(score_str.split('.')[1])
+                if decimals > 4:
+                    violations.append(f"{csv_path}:{line_num}: score={score_str} has {decimals} decimals")
+    assert not violations, "Scores with more than 4 decimal places found:\n" + "\n".join(violations)
+
+
 @pytest.fixture
 def create_specncl():
     def simple_specncl(config):
@@ -108,6 +132,8 @@ def test_specncl_scores(tmp_path, create_specncl):
         scores_path=scores_path.joinpath(config['name'] + '.csv')
     )
 
+    assert_scores_have_max_4_decimals(scores_path.joinpath(config['name'] + '.csv'))
+
 
 def test_sparse_scores(tmp_path, create_specncl):
     config = {
@@ -151,6 +177,9 @@ def test_sparse_scores(tmp_path, create_specncl):
 
     if config['model_params'].get('sparse_value'):
         all_scores = generate_sparse_scores(all_scores, config['model_params']['sparse_value'], scores_path.joinpath(config['name'] + '_sparse.csv'))
+
+    assert_scores_have_max_4_decimals(scores_path.joinpath(config['name'] + '.csv'))
+    assert_scores_have_max_4_decimals(scores_path.joinpath(config['name'] + '_sparse.csv'))
 
     assert len(all_scores) == 8
     for row in all_scores:
@@ -416,44 +445,3 @@ def test_self_similarity_score_within_bounds(tmp_path):
 
 
 
-def test_score_decimal_precision():
-    """Test that all scores have at most 4 decimal places."""
-    import os
-    import re
-    from pathlib import Path
-    
-    # Get the scores directory
-    scores_dir = Path('tests/test_workflow/scores')
-    
-    # Find all score files (csv files)
-    score_files = list(scores_dir.glob('*.csv'))
-    
-    # If no files exist, skip (they're generated during other tests)
-    if not score_files:
-        pytest.skip("No score files found - run other tests first")
-    
-    decimal_violations = []
-    
-    for score_file in score_files:
-        with open(score_file, 'r') as f:
-            for line_num, line in enumerate(f, 1):
-                line = line.strip()
-                if not line:
-                    continue
-                # Parse CSV: note_id,reviewer,score
-                parts = line.split(',')
-                if len(parts) >= 3:
-                    score_str = parts[-1]
-                    try:
-                        score = float(score_str)
-                        # Check decimal places
-                        if '.' in score_str:
-                            decimals = len(score_str.split('.')[1])
-                            if decimals > 4:
-                                decimal_violations.append(
-                                    f"{score_file}:{line_num}: score={score_str} has {decimals} decimal places"
-                                )
-                    except ValueError:
-                        continue
-    
-    assert len(decimal_violations) == 0, "Scores with more than 4 decimal places found:\n" + "\n".join(decimal_violations)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import time
 from collections import Counter
 from expertise.utils.utils import generate_job_id, JOB_ID_ALPHABET
 import expertise.service
+from expertise.service import artifacts_for_model
 
 
 def test_generate_job_id_gcp_compliance():
@@ -112,3 +113,29 @@ def test_create_app_config_dict_overrides_env(monkeypatch, tmp_path, temp_env_cf
     )
 
     assert app.config['EXPERTISE_ENV'] == 'override'
+
+
+@pytest.mark.parametrize("model, expected_subdirs", [
+    ('bm25', []),
+    ('specter', ['hf_models/specter']),
+    ('mfr', ['multifacet_recommender']),
+    ('specter+mfr', ['hf_models/specter', 'multifacet_recommender']),
+    ('specter2', ['hf_models/specter2_base', 'hf_models/specter2_adapter']),
+    ('scincl', ['hf_models/scincl']),
+    ('specter2+scincl', [
+        'hf_models/specter2_base',
+        'hf_models/specter2_adapter',
+        'hf_models/scincl',
+    ]),
+])
+def test_artifacts_for_model_returns_only_needed_subdirs(model, expected_subdirs):
+    """Pipeline workers download only the artifacts their model needs — this
+    map is the contract wiring that selective-download into run_pipeline."""
+    assert artifacts_for_model(model) == expected_subdirs
+
+
+def test_artifacts_for_model_unknown_model_falls_back_to_all():
+    """Unknown model names fall back to downloading everything (None) so a new
+    model added to the API doesn't break the pipeline before the map is updated."""
+    assert artifacts_for_model('some-unreleased-model') is None
+    assert artifacts_for_model(None) is None


### PR DESCRIPTION
### Summary
Pre-downloading HuggingFace models at image build time bloated the container to ~8 GB. Mirror the HF snapshots to `gs://openreview-expertise/expertise-utils/hf_models/` and fetch them at job start instead. Pipeline workers only pull the artifacts needed for the model they'll run. MFR flows through the same download path — CI no longer `wget`s a tarball.

### Motivation
HF pre-downloads were added in #354 because Vertex AI workers occasionally couldn't reach HuggingFace Hub at job start. That fix worked but bloated the image. Mirroring the snapshots in the same GCS bucket we already use for MFR + legacy specter gives us both reliability (no HF dependency at runtime) and a smaller image.

### Key changes
- `load_model_artifacts(subdirs=[...])` — selective per-job download driven by a new `artifacts_for_model(model)` map.
- Predictors load HF snapshots from local paths (via `SPECTER_HF_DIR`, `SPECTER2_HF_DIR`, `SPECTER2_ADAPTER_DIR`, `SCINCL_HF_DIR`), falling back to HF hub IDs for local dev.
- Model-loading logs now tag the source: `[source=BUCKET (local dir)]` vs `[source=HUGGINGFACE HUB (network)]`.
- CI pulls all model artifacts from the bucket in a single step before tests run.
- README has a new "Download model artifacts" section explaining the bucket-first setup and the HF fallback.

### Follow-ups
- Drop the dead `specter_dir` / `model_archive_file` / `vocab_dir` plumbing left over from the old AllenNLP specter loader.