### PR TITLE
Remove OpenReview client from Vertex AI pipeline; fix shared-singleton race in `GCPInterface`

### DIFF
--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -1,10 +1,8 @@
 import argparse
 import os
-import openreview
-import shortuuid
 import json
 import csv
-from expertise.execute_expertise import execute_create_dataset, execute_expertise
+from expertise.execute_expertise import execute_expertise
 from expertise.service import load_model_artifacts, artifacts_for_model
 from expertise.service.utils import APIRequest, JobConfig, ExpectedDataError
 from expertise.utils.utils import generate_job_id
@@ -104,23 +102,19 @@ def run_pipeline(
             raw_request = download_from_gcs(gcs_dir)
             print("Parsed request from GCS folder")
         
-        # Pop base URLs and other expected variables
+        # Pop pipeline-only metadata. The pipeline doesn't authenticate against
+        # OpenReview, so token/baseurl_v2 are not part of the upload anymore.
         print('Popping variables')
         for field in DELETED_FIELDS:
             raw_request.pop(field, None)
-        token = raw_request.pop('token')
-        baseurl_v2 = raw_request.pop('baseurl_v2')
         destination_prefix = raw_request.pop('gcs_folder')
         # dump_embs removed - embeddings always uploaded
         dump_archives = False if 'dump_archives' not in raw_request else raw_request.pop('dump_archives')
-        specter_dir = os.getenv('SPECTER_DIR')
-        mfr_vocab_dir = os.getenv('MFR_VOCAB_DIR')
-        mfr_checkpoint_dir = os.getenv('MFR_CHECKPOINT_DIR')
-        server_config ={
-            'OPENREVIEW_BASEURL_V2': baseurl_v2,
-            'SPECTER_DIR': specter_dir,
-            'MFR_VOCAB_DIR': mfr_vocab_dir,
-            'MFR_CHECKPOINT_DIR': mfr_checkpoint_dir,
+        server_config = {
+            'OPENREVIEW_BASEURL_V2': os.getenv('OPENREVIEW_BASEURL_V2', ''),
+            'SPECTER_DIR': os.getenv('SPECTER_DIR'),
+            'MFR_VOCAB_DIR': os.getenv('MFR_VOCAB_DIR'),
+            'MFR_CHECKPOINT_DIR': os.getenv('MFR_CHECKPOINT_DIR'),
         }
         _, bucket = load_gcs(destination_prefix)
         blob_prefix = '/'.join(destination_prefix.split('/')[3:])
@@ -132,15 +126,16 @@ def run_pipeline(
         print(f'Loading model artifacts for model={requested_model}: {required_artifacts}')
         load_model_artifacts(subdirs=required_artifacts)
 
-        print('Logging into OpenReview')
-        client_v2 = openreview.api.OpenReviewClient(baseurl=baseurl_v2, token=token)
-
         print('Creating job ID')
         job_id = generate_job_id()
         if working_dir is None:
             working_dir = f"/app/{job_id}"
         os.makedirs(working_dir, exist_ok=True)
 
+        # APIRequest.validate(client) is NOT called here — the pipeline performs
+        # no remote lookups and consumes nothing that validate() resolves
+        # (user_id, edge invitation labels). Permissions were enforced on the
+        # worker side. from_request runs as pure transformation.
         validated_request = APIRequest({
             'name': raw_request['name'],
             'entityA': raw_request['entityA'],
@@ -152,7 +147,6 @@ def run_pipeline(
         config = JobConfig.from_request(
             api_request = validated_request,
             starting_config = DEFAULT_CONFIG,
-            openreview_client_v2= client_v2,
             server_config = server_config,
             working_dir = working_dir,
         )

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -129,9 +129,6 @@ class BaseExpertiseService:
             torch.cuda.empty_cache()
             gc.collect()
 
-    def set_client_v2(self, client_v2):
-        self.client_v2 = client_v2
-
     def start_queue_in_thread(self):
         def run_event_loop(loop):
             asyncio.set_event_loop(loop)
@@ -330,15 +327,12 @@ class BaseExpertiseService:
         :returns: (JobConfig, token)
         """
 
-        # Resolve client
-        or_client = client if client else self.client_v2
-
         self.logger.info(f"Incoming request - {request}")
         validated_request = APIRequest(request)
+        validated_request.validate(client)
         config = JobConfig.from_request(
             api_request = validated_request,
             starting_config = self.default_expertise_config,
-            openreview_client_v2= or_client,
             server_config = self.server_config,
             working_dir = self.working_dir
         )
@@ -791,10 +785,6 @@ class ExpertiseCloudService(BaseExpertiseService):
             config=config,
             logger=logger
         )
-
-    def set_client_v2(self, client_v2):
-        self.client_v2 = client_v2
-        self.cloud.set_client(client_v2)
 
     def compute_machine_type_from_dataset(self, config):
         """Compute machine type from the already-created dataset on disk.

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -322,9 +322,14 @@ class BaseExpertiseService:
         """
         Validate and build a JobConfig for a request.
 
-        :param request: Submitted job request
-        :param job_id: Optional job id to reuse
-        :returns: (JobConfig, token)
+        Wraps the request in an APIRequest, calls APIRequest.validate(client)
+        to resolve OpenReview-dependent fields (user_id, expertise-edge
+        invitation labels) and enforce caller permissions (machine_type),
+        then transforms it into a JobConfig via JobConfig.from_request.
+
+        :param client: Authenticated OpenReview client for the calling user
+        :param request: Submitted job request body
+        :returns: The resolved JobConfig
         """
 
         self.logger.info(f"Incoming request - {request}")

--- a/expertise/service/routes.py
+++ b/expertise/service/routes.py
@@ -75,7 +75,6 @@ def expertise():
         user_request = flask.request.json
 
         expertise_service = get_expertise_service(flask.current_app.config, flask.current_app.logger)
-        expertise_service.set_client_v2(openreview_client_v2)
 
         request_key = expertise_service.get_key_from_request(user_request)
 
@@ -134,14 +133,12 @@ def jobs():
     :type job_id: str
     """
     try:
-        openreview_client_v2 = g.or_client_v2
         user_id = g.user_id
 
         flask.current_app.logger.debug('GET receives ' + str(flask.request.args))
         # Parse query parameters
         job_id = flask.request.args.get('jobId', None)
         expertise_service = get_expertise_service(flask.current_app.config, flask.current_app.logger)
-        expertise_service.set_client_v2(openreview_client_v2)
         if job_id is None or len(job_id) == 0:
             result = expertise_service.get_expertise_all_status(user_id, flask.request.args)
         else:
@@ -182,12 +179,10 @@ def all_jobs():
     :type job_id: str
     """
     try:
-        openreview_client_v2 = g.or_client_v2
         user_id = g.user_id
         # Parse query parameters
         flask.current_app.logger.debug('GET receives ' + str(flask.request.args))
         expertise_service = get_expertise_service(flask.current_app.config, flask.current_app.logger)
-        expertise_service.set_client_v2(openreview_client_v2)
         result = expertise_service.get_expertise_all_status(user_id, flask.request.args)
         flask.current_app.logger.debug('GET returns ' + str(result))
         return flask.jsonify(result), 200
@@ -229,11 +224,9 @@ def delete_job(job_id):
     :type job_id: str
     """
     try:
-        openreview_client_v2 = g.or_client_v2
         user_id = g.user_id
 
         expertise_service = get_expertise_service(flask.current_app.config, flask.current_app.logger)
-        expertise_service.set_client_v2(openreview_client_v2)
         result = expertise_service.del_expertise_job(user_id, job_id)
 
         return flask.jsonify(result), 200
@@ -275,7 +268,6 @@ def results():
     :type delete_on_get: bool
     """
     try:
-        openreview_client_v2 = g.or_client_v2
         user_id = g.user_id
         # Parse query parameters
         flask.current_app.logger.debug('GET receives ' + str(flask.request.args))
@@ -285,7 +277,6 @@ def results():
         delete_on_get = flask.request.args.get('deleteOnGet', 'False').lower() == 'true'
 
         expertise_service = get_expertise_service(flask.current_app.config, flask.current_app.logger)
-        expertise_service.set_client_v2(openreview_client_v2)
         result = expertise_service.get_expertise_results(user_id, job_id, delete_on_get)
         
         # Check if result is a generator (for streaming) or a regular dict

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -170,9 +170,19 @@ class APIRequest(object):
     def validate(self, openreview_client):
         """Resolve the fields that need an OpenReview client: the caller's
         user_id and any expertise-edge invitation labels. Also enforces caller
-        permissions (e.g. machine_type is restricted to superusers). Must be
-        called before this APIRequest is consumed by JobConfig.from_request,
-        which itself makes no remote calls and does no permission checks."""
+        permissions (e.g. machine_type is restricted to superusers).
+
+        Required on the *worker* path — call this once on the same APIRequest
+        instance that will be passed to JobConfig.from_request, so the resolved
+        fields are populated and the permission check runs against the caller's
+        identity.
+
+        Not required on the Vertex AI pipeline path. JobConfig.from_request is
+        pure transformation and the pipeline doesn't consume any field that
+        validate() resolves (user_id, inclusion_inv/exclusion_inv, etc.) nor
+        does it re-enforce permissions — those were already checked on the
+        worker side. The pipeline therefore performs zero remote OpenReview
+        calls."""
         self.user_id = get_user_id(openreview_client)
 
         if self.user_id not in SUPERUSER_IDS and self.machine_type is not None:

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -77,6 +77,13 @@ class APIRequest(object):
         self.model = {}
         self.dataset = {}
         self.machine_type = None
+        # Populated by validate(client) — the OpenReview-dependent fields.
+        # JobConfig.from_request reads these directly and makes no remote calls.
+        self.user_id = None
+        self.inclusion_inv = None
+        self.exclusion_inv = None
+        self.alternate_inclusion_inv = None
+        self.alternate_exclusion_inv = None
         root_key = 'request'
 
         def _get_field_from_request(field):
@@ -159,7 +166,51 @@ class APIRequest(object):
         # Check for extra entity fields
         if len(source_entity.keys()) > 0:
             raise openreview.OpenReviewException(f"Bad request: unexpected fields in {entity_id}: {list(source_entity.keys())}")
-        
+
+    def validate(self, openreview_client):
+        """Resolve the fields that need an OpenReview client: the caller's
+        user_id and any expertise-edge invitation labels. Also enforces caller
+        permissions (e.g. machine_type is restricted to superusers). Must be
+        called before this APIRequest is consumed by JobConfig.from_request,
+        which itself makes no remote calls and does no permission checks."""
+        self.user_id = get_user_id(openreview_client)
+
+        if self.user_id not in SUPERUSER_IDS and self.machine_type is not None:
+            raise openreview.OpenReviewException(
+                'Forbidden: Insufficient permissions to set machine type'
+            )
+
+        if self.entityA.get('type') == 'Group':
+            edge_inv = self.entityA.get('expertise')
+            if edge_inv:
+                edge_inv_id = self._extract_edge_inv_id(edge_inv)
+                label = self._fetch_edge_label(openreview_client, edge_inv_id)
+                if 'exclude' not in label.lower():
+                    self.inclusion_inv = edge_inv_id
+                else:
+                    self.exclusion_inv = edge_inv_id
+
+        if self.entityB.get('type') == 'Group':
+            edge_inv = self.entityB.get('expertise')
+            if edge_inv:
+                edge_inv_id = self._extract_edge_inv_id(edge_inv)
+                label = self._fetch_edge_label(openreview_client, edge_inv_id)
+                if 'include' in label.lower():
+                    self.alternate_inclusion_inv = edge_inv_id
+                else:
+                    self.alternate_exclusion_inv = edge_inv_id
+
+    @staticmethod
+    def _extract_edge_inv_id(edge_inv):
+        edge_inv_id = edge_inv.get('exclusion', {}).get('invitation') or edge_inv.get('invitation')
+        if not edge_inv_id:
+            raise openreview.OpenReviewException('Bad request: Expertise invitation indicated but ID not provided')
+        return edge_inv_id
+
+    @staticmethod
+    def _fetch_edge_label(openreview_client, edge_inv_id):
+        return openreview_client.get_invitation(edge_inv_id).edit.get('label', {}).get('param', {}).get('enum', ['Include'])[0]
+
     def to_json(self):
         body = {
             'name': self.name,
@@ -481,7 +532,6 @@ class JobConfig(object):
     def from_request(api_request: APIRequest,
         job_id=None,
         starting_config = {},
-        openreview_client_v2 = None,
         server_config = {},
         working_dir = None):
         """
@@ -522,13 +572,14 @@ class JobConfig(object):
 
         # Set metadata fields from request
         config.name = api_request.name
-        config.user_id = get_user_id(openreview_client_v2)
+        # user_id is resolved by APIRequest.validate(client); no remote call here.
+        config.user_id = api_request.user_id
         config.job_id = generate_job_id() if job_id is None else job_id
         config.baseurl_v2 = server_config['OPENREVIEW_BASEURL_V2']
         config.api_request = api_request    
         
-        if config.user_id not in SUPERUSER_IDS and api_request.machine_type is not None:
-            raise openreview.OpenReviewException('Forbidden: Insufficient permissions to set machine type')
+        # Permission check (machine_type only for superusers) lives in
+        # APIRequest.validate(client) — from_request is pure transformation.
         config.machine_type = api_request.machine_type
 
         root_dir = os.path.join(working_dir, config.job_id)
@@ -548,44 +599,20 @@ class JobConfig(object):
 
         # TODO: Need new keyword
 
+        # Edge-invitation labels are resolved by APIRequest.validate(client);
+        # we just copy the resolved fields onto the JobConfig here.
         if api_request.entityA['type'] == 'Group':
             if 'memberOf' in api_request.entityA:
                 config.match_group = [api_request.entityA['memberOf']]
             elif 'reviewerIds' in api_request.entityA:
                 config.reviewer_ids = api_request.entityA['reviewerIds']
-            edge_inv = api_request.entityA.get('expertise', None)
-
-            if edge_inv:
-                edge_inv_id = edge_inv.get('exclusion', {}).get('invitation', None)
-                if edge_inv_id is None:
-                    edge_inv_id = edge_inv.get('invitation', None)
-                if edge_inv_id is None or len(edge_inv_id) <= 0:
-                    raise openreview.OpenReviewException('Bad request: Expertise invitation indicated but ID not provided')
-
-                label = openreview_client_v2.get_invitation(edge_inv_id).edit.get('label', {}).get('param', {}).get('enum',['Include'])[0]
-
-                if 'exclude' not in label.lower():
-                    config.inclusion_inv = edge_inv_id
-                else:
-                    config.exclusion_inv = edge_inv_id
+            config.inclusion_inv = api_request.inclusion_inv
+            config.exclusion_inv = api_request.exclusion_inv
 
         if api_request.entityB['type'] == 'Group':
             config.alternate_match_group = [api_request.entityB['memberOf']]
-            edge_inv = api_request.entityB.get('expertise', None)
-
-            if edge_inv:
-                edge_inv_id = edge_inv.get('exclusion', {}).get('invitation', None)
-                if edge_inv_id is None:
-                    edge_inv_id = edge_inv.get('invitation', None)
-                if edge_inv_id is None:
-                    raise openreview.OpenReviewException('Bad request: Expertise invitation indicated but ID not provided')
-
-                label = openreview_client_v2.get_invitation(edge_inv_id).edit.get('label', {}).get('param', {}).get('enum',['Include'])[0]
-
-                if 'include' in label.lower():
-                    config.alternate_inclusion_inv = edge_inv_id
-                else:
-                    config.alternate_exclusion_inv = edge_inv_id
+            config.alternate_inclusion_inv = api_request.alternate_inclusion_inv
+            config.alternate_exclusion_inv = api_request.alternate_exclusion_inv
 
         # Handle Note cases
         config.paper_invitation = None
@@ -765,10 +792,9 @@ class GCPInterface(object):
         pipeline_root=None,
         pipeline_name=None,
         pipeline_repo=None,
-        bucket_name=None, 
+        bucket_name=None,
         jobs_folder=None,
         service_label=None,
-        openreview_client=None,
         pipeline_tag='latest',
         logger=None,
         gcs_client=None,
@@ -819,7 +845,6 @@ class GCPInterface(object):
             self.service_label
         ]
         
-        self.client = openreview_client
         self.request_fname = "request.json"
         if logger is None:
             logger = logging.getLogger(__name__)
@@ -845,9 +870,6 @@ class GCPInterface(object):
         )
         self.logger.info(f"Get bucket {self.bucket_name}")
         self.bucket = self.gcs_client.bucket(self.bucket_name)
-
-    def set_client(self, client):
-        self.client = client
 
     def _resolve_job_status(self, job_id, job):
         descriptions = JobDescription.VALS.value
@@ -945,7 +967,7 @@ class GCPInterface(object):
         self.logger.info(f"Dataset uploaded to {dataset_gcs_path}")
         return dataset_gcs_path
 
-    def create_job(self, json_request: dict, job_id: str, user_id: str = None, machine_type = None, dataset_gcs_path: str = None, vertex_id: str = None):
+    def create_job(self, json_request: dict, job_id: str, user_id: str, machine_type = None, dataset_gcs_path: str = None, vertex_id: str = None):
         def create_folder(bucket_name, folder_path):
             client = storage.Client()
             bucket = client.get_bucket(bucket_name)
@@ -992,16 +1014,12 @@ class GCPInterface(object):
         # Expected fields
         data['name'] = valid_vertex_id
 
-        # Popped fields
-        data['baseurl_v2'] = openreview.tools.get_base_urls(self.client)[1]
-        data['token'] = self.client.token
+        # The pipeline doesn't authenticate against OpenReview, so we don't
+        # ship a token or baseurl. Status checks read user_id/machine_type/cdate
+        # from the top of this payload; the rest is the original request shape.
         data['gcs_folder'] = f"gs://{self.bucket_name}/{folder_path}"
-        #data['dump_embs'] = True
-        #data['dump_archives'] = True
-
-        # Deleted metadata fields before hitting the pipeline
         data['machine_type'] = machine_type
-        data['user_id'] = user_id if user_id else get_user_id(self.client)
+        data['user_id'] = user_id
         data['cdate'] = int(time.time() * 1000)
 
         write_json_to_gcs(self.bucket_name, folder_path, self.request_fname, data)

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -494,13 +494,14 @@ class JobConfig(object):
         self.api_request = None
 
     def to_json(self):
+        # baseurl / baseurl_v2 deliberately omitted: runtime-only fields the
+        # worker uses to construct the OpenReview client for dataset creation;
+        # never consumed by anything reading job_config.json from disk/GCS.
         json_keys = [
             'name',
             'user_id',
             'job_id',
             'cloud_id',
-            'baseurl',
-            'baseurl_v2',
             'job_dir',
             'cdate',
             'mdate',
@@ -750,8 +751,6 @@ class JobConfig(object):
             name = job_config.get('name'),
             user_id = job_config.get('user_id'),
             job_id = job_config.get('job_id'),
-            baseurl = job_config.get('baseurl'),
-            baseurl_v2 = job_config.get('baseurl_v2'),
             job_dir = job_config.get('job_dir'),
             cdate = job_config.get('cdate'),
             mdate = job_config.get('mdate'),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='openreview-expertise',
-    version='2.1.3',
+    version='2.1.4',
     description='OpenReview paper-reviewer affinity modeling',
     url='https://github.com/openreview/openreview-expertise',
     author='OpenReview',

--- a/tests/test_expertise_cloud_service.py
+++ b/tests/test_expertise_cloud_service.py
@@ -11,7 +11,7 @@ import numpy as np
 import shutil
 import expertise.service
 from expertise.dataset import ArchivesDataset, SubmissionsDataset
-from expertise.service.utils import JobConfig, RedisDatabase, get_user_id
+from expertise.service.utils import JobConfig, RedisDatabase
 from google.cloud.aiplatform_v1.types import PipelineState
 from conftest import GCSTestHelper
 from expertise.service.utils import RedisDatabase, JobConfig, JobStatus, JobDescription, APIRequest
@@ -921,19 +921,7 @@ class TestExpertiseCloudService():
             
             assert response.status_code == 200, f"Failed to submit job: {response.json}"
             job_id_b = response.json['jobId']
-            
-            # Get the service from routes to check its current state
-            from expertise.service.routes import get_expertise_service
-            with openreview_context_cloud['app'].app_context():
-                service = get_expertise_service(openreview_context_cloud['config'], openreview_context_cloud['app'].logger)
-                
-                # Check current client's user
-                current_user = get_user_id(service.cloud.client)
-                print(f"Current client user: {current_user}")
-                
-                # This should match User B (the last user to submit)
-                assert current_user == "TMLR", f"Expected client for TMLR but got {current_user}"
-            
+
             # Wait for both jobs to be processed
             time.sleep(openreview_context_cloud['config']['POLL_INTERVAL'] * openreview_context_cloud['config']['POLL_MAX_ATTEMPTS'] * 2 + LATENCY_OFFSET)
             

--- a/tests/test_gcp_interface.py
+++ b/tests/test_gcp_interface.py
@@ -6,7 +6,9 @@ import datetime
 import time
 import os
 import tempfile
+import threading
 import openreview
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from expertise.service.utils import GCPInterface, JobDescription, JobStatus, JobConfig, APIRequest
 from google.cloud.aiplatform_v1.types import PipelineState
@@ -80,7 +82,7 @@ def _setup_abc_cc(clean_start_conference, client, openreview_client):
 @patch("expertise.service.utils.time.time")  # Mock time.time()
 @patch("expertise.service.utils.aip.PipelineJob")  # Mock PipelineJob
 @patch("expertise.service.utils.storage.Client")  # Mock GCS Client
-def test_create_job(mock_storage_client, mock_pipeline_job, mock_time, openreview_client):
+def test_create_job(mock_storage_client, mock_pipeline_job, mock_time):
     # Mock time.time() to return a fixed value
     mock_time.return_value = 1234567890.123  # Fixed timestamp for testing
     
@@ -107,7 +109,6 @@ def test_create_job(mock_storage_client, mock_pipeline_job, mock_time, openrevie
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -133,11 +134,11 @@ def test_create_job(mock_storage_client, mock_pipeline_job, mock_time, openrevie
 
     # Generate a test job_id
     test_job_id = generate_job_id()
-    
+
     # Call the `create_job` method
     # deepcopy because APIRequest() destroys the original
-    result = gcp_interface.create_job(deepcopy(json_request), job_id=test_job_id, machine_type='small', user_id='openreview.net')
-    
+    result = gcp_interface.create_job(deepcopy(json_request), job_id=test_job_id, user_id='openreview.net', machine_type='small')
+
     expected_timestamp_ms = int(1234567890.123 * 1000)  # 1234567890123
     expected_valid_vertex_id = f"{test_job_id}-{expected_timestamp_ms}"
     assert result == expected_valid_vertex_id
@@ -160,11 +161,12 @@ def test_create_job(mock_storage_client, mock_pipeline_job, mock_time, openrevie
     assert submitted_json['name'] == result
     assert submitted_json['entityA'] == json_request['entityA']
     assert submitted_json['entityB'] == json_request['entityB']
-    assert submitted_json['token'] == openreview_client.token
-    assert submitted_json['baseurl_v2'] == 'http://localhost:3001'
     assert submitted_json['gcs_folder'] == f"gs://test-bucket/{expected_folder_path}"
     assert submitted_json['user_id'] == 'openreview.net'
     assert submitted_json['cdate'] == expected_timestamp_ms  # Verify timestamp is stored
+    # Pipeline doesn't authenticate, so neither token nor baseurl is uploaded.
+    assert 'token' not in submitted_json
+    assert 'baseurl_v2' not in submitted_json
 
     # 3. Verify PipelineJob submission
     mock_pipeline_job.assert_called_once_with(
@@ -184,7 +186,7 @@ def test_create_job(mock_storage_client, mock_pipeline_job, mock_time, openrevie
 @patch("expertise.service.utils.time.time")  # Mock time.time()
 @patch("expertise.service.utils.aip.PipelineJob")  # Mock PipelineJob
 @patch("expertise.service.utils.storage.Client")  # Mock GCS Client
-def test_create_job_with_service_account(mock_storage_client, mock_pipeline_job, mock_time, openreview_client):
+def test_create_job_with_service_account(mock_storage_client, mock_pipeline_job, mock_time):
     mock_time.return_value = 1234567890.123
 
     # Setup mock storage client
@@ -212,8 +214,7 @@ def test_create_job_with_service_account(mock_storage_client, mock_pipeline_job,
         'GCP_SERVICE_ACCOUNT': 'sa-under-test@test-project.iam.gserviceaccount.com',
     }
     gcp_interface = GCPInterface(
-        config=config,
-        openreview_client=openreview_client
+        config=config
     )
 
     json_request = {
@@ -223,7 +224,7 @@ def test_create_job_with_service_account(mock_storage_client, mock_pipeline_job,
         "model": {"name": "specter+mfr", 'useTitle': False, 'useAbstract': True, 'skipSpecter': False, 'scoreComputation': 'avg'}
     }
     test_job_id = generate_job_id()
-    result = gcp_interface.create_job(deepcopy(json_request), job_id=test_job_id, machine_type='small')
+    result = gcp_interface.create_job(deepcopy(json_request), job_id=test_job_id, user_id='openreview.net', machine_type='small')
 
     expected_timestamp_ms = int(1234567890.123 * 1000)
     expected_valid_vertex_id = f"{test_job_id}-{expected_timestamp_ms}"
@@ -249,7 +250,7 @@ def test_create_job_with_service_account(mock_storage_client, mock_pipeline_job,
 @patch("expertise.service.utils.time.time")
 @patch("expertise.service.utils.aip.PipelineJob")
 @patch("expertise.service.utils.storage.Client")
-def test_machine_type_not_in_pipeline_parameter_values(mock_storage_client, mock_pipeline_job, mock_time, openreview_client):
+def test_machine_type_not_in_pipeline_parameter_values(mock_storage_client, mock_pipeline_job, mock_time):
     mock_time.return_value = 1234567890.123
     mock_bucket = MagicMock()
     mock_blob = MagicMock()
@@ -270,7 +271,7 @@ def test_machine_type_not_in_pipeline_parameter_values(mock_storage_client, mock
         'GCP_JOBS_FOLDER': 'jobs',
         'GCP_SERVICE_LABEL': {'test': 'label'},
     }
-    gcp_interface = GCPInterface(config=config, openreview_client=openreview_client)
+    gcp_interface = GCPInterface(config=config)
 
     json_request = {
         "name": "test_run_machine_type",
@@ -278,7 +279,7 @@ def test_machine_type_not_in_pipeline_parameter_values(mock_storage_client, mock
         "entityB": {'type': "Note", 'invitation': "GCP.cc/-/Submission"},
         "model": {"name": "specter+mfr", 'useTitle': False, 'useAbstract': True, 'skipSpecter': False, 'scoreComputation': 'avg'}
     }
-    gcp_interface.create_job(deepcopy(json_request), job_id=generate_job_id(), machine_type='small')
+    gcp_interface.create_job(deepcopy(json_request), job_id=generate_job_id(), user_id='openreview.net', machine_type='small')
 
     _, kwargs = mock_pipeline_job.call_args
     params = kwargs['parameter_values']
@@ -286,6 +287,89 @@ def test_machine_type_not_in_pipeline_parameter_values(mock_storage_client, mock
         "machine_type must not be passed as a pipeline parameter — it is used only "
         "for tier-based pipeline selection and is not defined in any pipeline's input definitions"
     )
+
+# Race-condition regression: a single shared GCPInterface (the production singleton)
+# must not leak one caller's identity into another caller's request.json. The original
+# bug was a shared self.client attribute that concurrent requests overwrote; today
+# create_job takes user_id per call and does not retain a client, so there's no
+# shared mutable state to leak. This test pins that property.
+@patch("expertise.service.utils.aip.PipelineJob")
+@patch("expertise.service.utils.storage.Client")
+def test_create_job_isolates_user_across_concurrent_calls(mock_storage_client, mock_pipeline_job):
+    captured_payloads = []
+    captured_lock = threading.Lock()
+
+    def make_blob(*args, **kwargs):
+        blob = MagicMock()
+        def upload_from_string(*args, **kwargs):
+            data = kwargs.get('data')
+            if data is None and args:
+                data = args[0]
+            if isinstance(data, str) and data.startswith('{'):
+                with captured_lock:
+                    captured_payloads.append(json.loads(data))
+        blob.upload_from_string.side_effect = upload_from_string
+        return blob
+
+    fake_bucket = MagicMock()
+    fake_bucket.blob.side_effect = make_blob
+    fake_bucket.list_blobs.return_value = []
+    mock_storage_client.return_value.bucket.return_value = fake_bucket
+    mock_storage_client.return_value.get_bucket.return_value = fake_bucket
+    mock_pipeline_job.return_value = MagicMock()
+
+    # ONE shared GCPInterface — mirrors the production singleton in ExpertiseCloudService.
+    gcp_interface = GCPInterface(
+        project_id="test_project",
+        project_number="123456",
+        region="us-central1",
+        pipeline_root="pipeline-root",
+        pipeline_name="test-pipeline",
+        pipeline_repo="test-repo",
+        bucket_name="test-bucket",
+        jobs_folder="jobs",
+        service_label={'test': 'label'},
+    )
+
+    NUM_USERS = 16
+    barrier = threading.Barrier(NUM_USERS)
+
+    def submit(i):
+        # Synchronize so all threads enter create_job at the same moment — this
+        # would have caused user_id cross-contamination under the old shared
+        # self.client singleton design.
+        barrier.wait()
+        return gcp_interface.create_job(
+            {
+                "name": f"job-{i}",
+                "entityA": {'type': "Group", 'memberOf': "GCP.cc/Reviewers"},
+                "entityB": {'type': "Note", 'invitation': "GCP.cc/-/Submission"},
+                "model": {"name": "specter+mfr"},
+            },
+            job_id=f"job-{i}",
+            user_id=f"user-{i}",
+            machine_type='small',
+        )
+
+    with ThreadPoolExecutor(max_workers=NUM_USERS) as executor:
+        list(executor.map(submit, range(NUM_USERS)))
+
+    # One request.json per call; each must carry that call's own user_id, and
+    # nothing authentication-related should ever land in the upload.
+    assert len(captured_payloads) == NUM_USERS, (
+        f"Expected {NUM_USERS} request.json uploads, got {len(captured_payloads)}"
+    )
+
+    captured_user_ids = sorted(p['user_id'] for p in captured_payloads)
+    expected_user_ids = sorted(f"user-{i}" for i in range(NUM_USERS))
+    assert captured_user_ids == expected_user_ids, (
+        f"user_id leak across concurrent calls. Expected {expected_user_ids}, "
+        f"got {captured_user_ids}"
+    )
+
+    for payload in captured_payloads:
+        assert 'token' not in payload
+        assert 'baseurl_v2' not in payload
 
 # Test case for `upload_dataset` — verifies that dataset files are actually uploaded to the bucket
 @patch("expertise.service.utils.transfer_manager")  # Mock transfer_manager
@@ -303,7 +387,6 @@ def test_upload_dataset(mock_storage_client, mock_transfer_manager, openreview_c
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -377,7 +460,6 @@ def test_upload_dataset_with_vertex_id(mock_storage_client, mock_transfer_manage
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -411,7 +493,6 @@ def test_upload_dataset_empty_directory(mock_storage_client, mock_transfer_manag
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -457,7 +538,6 @@ def test_get_job_status_by_job_id(mock_storage_client, mock_pipeline_job_get, op
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -526,7 +606,6 @@ def test_get_job_status_by_job_id_job_not_found(mock_storage_client, openreview_
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -583,7 +662,6 @@ def test_get_job_status_by_job_id_insufficient_permissions(mock_storage_client, 
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -647,7 +725,6 @@ def test_get_job_status_by_job_id_multiple_requests(mock_storage_client, mock_pi
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -735,7 +812,6 @@ def test_get_job_status(mock_storage_client, mock_pipeline_job_get, openreview_c
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -823,7 +899,6 @@ def test_get_job_status_multiple_filters(mock_storage_client, mock_pipeline_job_
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -866,7 +941,6 @@ def test_get_job_status_insufficient_permissions(mock_storage_client, openreview
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -936,7 +1010,6 @@ def test_get_job_results(mock_storage_client, openreview_client):
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -985,7 +1058,6 @@ def test_get_job_results_missing_metadata(mock_storage_client, openreview_client
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -1019,7 +1091,6 @@ def test_get_job_results_insufficient_permissions(mock_storage_client, openrevie
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={'test': 'label'}
     )
 
@@ -1077,7 +1148,6 @@ def test_get_job_results_group_scoring(mock_storage_client):
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=MagicMock()
     )
 
     # Call the method
@@ -1137,7 +1207,6 @@ def test_get_job_status_by_job_id_returns_redis_when_no_cloud_id(mock_storage_cl
         pipeline_repo="test-repo",
         bucket_name="test-bucket",
         jobs_folder="jobs",
-        openreview_client=openreview_client,
         service_label={"test": "label"},
     )
 


### PR DESCRIPTION
### Summary
- `GCPInterface` no longer retains an OpenReview client. The race condition where one user's job could be submitted to Vertex AI under another user's identity is gone — the bug source (a mutable `self.client` on a singleton) is removed, not patched.
- The Vertex AI pipeline performs zero remote OpenReview calls. It no longer receives a token or baseurl in its payload, doesn't construct a client, and doesn't call `validate()`. `JobConfig.from_request` is pure transformation now.
- `JobConfig.from_request` no longer takes an OpenReview client. Permission checks and remote lookups (user_id, expertise-edge invitation labels) move to a new `APIRequest.validate(client)` that runs once on the worker.

### The race
- `ExpertiseCloudService` is a Flask-app singleton (via `@run_once`). It held `self.cloud = GCPInterface(...)` — also a singleton.
- Every authenticated route called `expertise_service.set_client_v2(openreview_client_v2)`, which mutated `self.cloud.client` in place.
- `GCPInterface.create_job(...)` then read `self.client.token`, `openreview.tools.get_base_urls(self.client)`, and `get_user_id(self.client)` to build `request.json`.
- Worker threads create per-job clients correctly for *dataset creation*, but `create_job` ignored those and read from the singleton's `self.client`. Any other request — even a `GET /expertise/status` from a different user — could overwrite the client between when User A's job was enqueued and when the worker called `create_job`. Result: User A's `request.json` written to GCS could carry User B's token, baseurl, and user_id, then the Vertex AI pipeline would run User A's job under User B's credentials.

### Changes

**`GCPInterface` — remove the shared mutable client**
- Removed `openreview_client` ctor param, `self.client`, and the `set_client(...)` setter.
- `create_job(json_request, job_id, user_id, machine_type=None, dataset_gcs_path=None, vertex_id=None)` — `user_id` is now required and explicit; the client is gone entirely. The uploaded `request.json` no longer contains `token` or `baseurl_v2`.
- `ExpertiseCloudService.set_client_v2` and `BaseExpertiseService.set_client_v2`/`self.client_v2` were removed (the latter's only consumer was a dead fallback in `_validate_request`). The five `set_client_v2(...)` calls in `routes.py` are gone.

**`APIRequest.validate(client)` — single point of contact with OpenReview**
- New method that resolves the OpenReview-dependent fields and enforces caller permissions:
  - `self.user_id = get_user_id(client)`
  - Permission check: `machine_type` is rejected for non-superusers.
  - For each Group entity with an `expertise` edge, fetch the invitation label via `client.get_invitation(...)` and store the resolved `inclusion_inv`/`exclusion_inv`/`alternate_inclusion_inv`/`alternate_exclusion_inv` on the request.
- Initialized to `None` in `__init__`. Two small static helpers (`_extract_edge_inv_id`, `_fetch_edge_label`) keep the lookup readable.

**`JobConfig.from_request` — pure transformation**
- Dropped the `openreview_client_v2` parameter.
- Reads `user_id` and the resolved invitations directly from `api_request`.
- The machine_type permission check moved to `APIRequest.validate`. `from_request` makes zero remote calls and zero permission checks; it just maps a validated `APIRequest` to a `JobConfig`.

**`_validate_request` (worker)**
- Calls `validated_request.validate(client)` once, then `JobConfig.from_request(...)`.

**`run_pipeline` (Vertex AI)**
- Dropped the `openreview` import, the `OpenReviewClient` construction, the `validate(client_v2)` call, the `token`/`baseurl_v2` pops, and `user_id` from `DELETED_FIELDS`.
- `from_request` runs as pure transformation. The pipeline does not authenticate against OpenReview at all, and its `request.json` no longer contains anything that could.

**Tests**
- New `tests/test_gcp_interface.py::test_create_job_isolates_user_across_concurrent_calls` — 16 threads hit a single shared `GCPInterface` through a barrier; asserts each call's `request.json` carries that call's own `user_id` and that no token or baseurl is ever uploaded. Verified externally against a simulated regression of the original singleton design (the simulation produced 15/16 token leaks — the test catches the bug pattern).
- Existing `tests/test_expertise_cloud_service.py::TestExpertiseCloudService::test_client_isolation` already covered the end-to-end scenario; it now passes against the cleaned-up code (intermediate `service.cloud.client` probe removed since that attribute is gone).
- `tests/test_gcp_interface.py` `create_job` tests updated for the new signature; the assertions on `token`/`baseurl_v2` flipped from "present" to "must not be uploaded".

### Test plan
- [x] `tests/test_gcp_interface.py` — 19/19 (including the new race-condition test)
- [x] `tests/test_pipeline.py` — 5/5
- [x] `tests/test_expertise_cloud_service.py::TestExpertiseCloudService::test_create_job_filesystem` — 1/1 (full E2E with real GCS + worker + Vertex AI mocks)
- [x] `tests/test_expertise_cloud_service.py::TestExpertiseCloudService::test_client_isolation` — 1/1
- [x] CI green on this branch.
- [x] Vertex AI smoke job: confirm pipeline still runs end-to-end with the leaner `request.json` payload.

### Notes
- The pipeline payload is now strictly smaller: no token, no baseurl. Status checks (`get_job_status_by_job_id`, `get_job_status`) still read `user_id`/`cdate`/`entityA`/`entityB`/`machine_type` from the top level — unchanged.
- A separate follow-up PR will look at whether the Vertex AI pipeline still needs to call `JobConfig.from_request` at all (the worker already produced a fully-resolved `config.json`); not in scope here to keep this change small.
