### PR TITLE
# Move from Python 3.11 (deadsnakes PPA) to Python 3.12; remove the PPA from every build environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     machine:
       image: ubuntu-2404:2026.02.2
     # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
-    resource_class: large
+    resource_class: large.gen2
     parallelism: 1
     working_directory: ~/openreview-expertise
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,13 @@ orbs:
 jobs:
   build:
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: ubuntu-2404:2026.02.2
     # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
     resource_class: large
     parallelism: 1
     working_directory: ~/openreview-expertise
     environment:
-      PYTHON_VERSION: 3.11
+      PYTHON_VERSION: 3.12
       GOOGLE_CLOUD_PROJECT: $GOOGLE_PROJECT_ID
       DEBIAN_FRONTEND: noninteractive
       NEEDRESTART_MODE: a
@@ -48,9 +48,6 @@ jobs:
           name: Install Python ${PYTHON_VERSION}
           command: |
             export APT_OPTS="NEEDRESTART_MODE=a DEBIAN_FRONTEND=noninteractive"
-            sudo env $APT_OPTS apt-get update
-            sudo env $APT_OPTS apt-get install -y software-properties-common
-            sudo env $APT_OPTS add-apt-repository -y ppa:deadsnakes/ppa
             sudo env $APT_OPTS apt-get update
             sudo env $APT_OPTS apt-get install -y \
               python${PYTHON_VERSION} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,9 @@ orbs:
 jobs:
   build:
     machine:
-      image: ubuntu-2404:2026.02.2
+      image: ubuntu-2204:2022.10.2
     # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
-    resource_class: large.gen2
+    resource_class: large
     parallelism: 1
     working_directory: ~/openreview-expertise
     environment:
@@ -45,16 +45,18 @@ jobs:
             gcloud auth list
             gcloud projects list
       - run:
-          name: Install Python ${PYTHON_VERSION}
+          name: Install Python ${PYTHON_VERSION} via uv
           command: |
             export APT_OPTS="NEEDRESTART_MODE=a DEBIAN_FRONTEND=noninteractive"
             sudo env $APT_OPTS apt-get update
-            sudo env $APT_OPTS apt-get install -y \
-              python${PYTHON_VERSION} \
-              python${PYTHON_VERSION}-venv \
-              python${PYTHON_VERSION}-dev
             sudo env $APT_OPTS apt-get install -y wget make gcc curl build-essential git sudo
             sudo env $APT_OPTS TZ=Etc/UTC apt-get install -y tzdata
+            # uv ships prebuilt CPython (python-build-standalone), so we get
+            # ${PYTHON_VERSION} without depending on ppa:deadsnakes.
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+            export PATH="$HOME/.local/bin:$PATH"
+            uv python install ${PYTHON_VERSION}
       - run:
           name: Install Node 22
           command: |
@@ -74,7 +76,7 @@ jobs:
       - run:
           name: Setup environment
           command: |
-            python${PYTHON_VERSION} -m venv ~/venv
+            uv venv --python ${PYTHON_VERSION} --seed ~/venv
             source ~/venv/bin/activate
             python -m pip install --upgrade pip setuptools wheel setuptools_rust
             python --version

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -84,10 +84,10 @@ jobs:
           else
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
-      - name: Setup Python 3.11
+      - name: Setup Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -71,10 +71,10 @@ jobs:
           else
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
-      - name: Setup Python 3.11
+      - name: Setup Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,29 @@
+FROM python:3.11-slim-bookworm AS builder
+
+ENV PIP_ROOT_USER_ACTION=ignore \
+    VIRTUAL_ENV="/app/venv" \
+    PATH="/app/venv/bin:${PATH}"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /app/openreview-expertise
+
+RUN python -m venv ${VIRTUAL_ENV} \
+    && pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cu124 \
+    && pip install --no-cache-dir filelock faiss-cpu \
+    && pip install --no-cache-dir -e /app/openreview-expertise
+
+
 FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04
 
 WORKDIR /app
 
-ENV PYTHON_VERSION=3.11 \
-    HOME="/app" \
+ENV HOME="/app" \
     PYTHONUNBUFFERED=1 \
-    PIP_ROOT_USER_ACTION=ignore \
     VIRTUAL_ENV="/app/venv" \
     PATH="/app/venv/bin:${PATH}" \
     AIP_STORAGE_URI="gs://openreview-expertise/expertise-utils/" \
@@ -17,29 +35,31 @@ ENV PYTHON_VERSION=3.11 \
     SPECTER2_ADAPTER_DIR="/app/expertise-utils/hf_models/specter2_adapter" \
     SCINCL_HF_DIR="/app/expertise-utils/hf_models/scincl"
 
-COPY . /app/openreview-expertise
-
+# Runtime libs the copied CPython 3.11 binary dynamically links against
+# (built on Debian bookworm; these are the Ubuntu 24.04 equivalents).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libgomp1 \
         ca-certificates \
-        build-essential \
-        software-properties-common \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        python${PYTHON_VERSION} \
-        python${PYTHON_VERSION}-venv \
-        python${PYTHON_VERSION}-dev \
-    && rm -rf /var/lib/apt/lists/* \
-    \
-    && python${PYTHON_VERSION} -m venv ${VIRTUAL_ENV} \
-    && pip install --no-cache-dir --upgrade pip setuptools wheel \
-    && pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cu124 \
-    && pip install --no-cache-dir filelock faiss-cpu \
-    && pip install --no-cache-dir -e /app/openreview-expertise \
-    && apt-get purge -y build-essential software-properties-common \
-    && apt-get autoremove -y \
+        libgomp1 \
+        libssl3 \
+        libffi8 \
+        libsqlite3-0 \
+        libreadline8 \
+        liblzma5 \
+        libbz2-1.0 \
+        libncursesw6 \
+        libuuid1 \
+        libexpat1 \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/bin/python3.11 /usr/local/bin/python3.11
+COPY --from=builder /usr/local/lib/python3.11 /usr/local/lib/python3.11
+COPY --from=builder /usr/local/lib/libpython3.11.so /usr/local/lib/libpython3.11.so
+COPY --from=builder /usr/local/lib/libpython3.11.so.1.0 /usr/local/lib/libpython3.11.so.1.0
+COPY --from=builder /app/venv /app/venv
+COPY --from=builder /app/openreview-expertise /app/openreview-expertise
+
+RUN ln -s /usr/local/bin/python3.11 /usr/local/bin/python3 \
+    && ldconfig
 
 # HuggingFace models (specter, specter2 base + adapter, scincl) are not baked into
 # the image — they are fetched from gs://openreview-expertise/expertise-utils/hf_models/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,10 @@
-FROM python:3.11-slim-bookworm AS builder
-
-ENV PIP_ROOT_USER_ACTION=ignore \
-    VIRTUAL_ENV="/app/venv" \
-    PATH="/app/venv/bin:${PATH}"
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential \
-        ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY . /app/openreview-expertise
-
-RUN python -m venv ${VIRTUAL_ENV} \
-    && pip install --no-cache-dir --upgrade pip setuptools wheel \
-    && pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cu124 \
-    && pip install --no-cache-dir filelock faiss-cpu \
-    && pip install --no-cache-dir -e /app/openreview-expertise
-
-
 FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04
 
 WORKDIR /app
 
 ENV HOME="/app" \
     PYTHONUNBUFFERED=1 \
+    PIP_ROOT_USER_ACTION=ignore \
     VIRTUAL_ENV="/app/venv" \
     PATH="/app/venv/bin:${PATH}" \
     AIP_STORAGE_URI="gs://openreview-expertise/expertise-utils/" \
@@ -35,31 +16,25 @@ ENV HOME="/app" \
     SPECTER2_ADAPTER_DIR="/app/expertise-utils/hf_models/specter2_adapter" \
     SCINCL_HF_DIR="/app/expertise-utils/hf_models/scincl"
 
-# Runtime libs the copied CPython 3.11 binary dynamically links against
-# (built on Debian bookworm; these are the Ubuntu 24.04 equivalents).
+COPY . /app/openreview-expertise
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates \
         libgomp1 \
-        libssl3 \
-        libffi8 \
-        libsqlite3-0 \
-        libreadline8 \
-        liblzma5 \
-        libbz2-1.0 \
-        libncursesw6 \
-        libuuid1 \
-        libexpat1 \
+        ca-certificates \
+        build-essential \
+        python3.12 \
+        python3.12-venv \
+        python3.12-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && python3.12 -m venv ${VIRTUAL_ENV} \
+    && pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cu124 \
+    && pip install --no-cache-dir filelock faiss-cpu \
+    && pip install --no-cache-dir -e /app/openreview-expertise \
+    && apt-get purge -y build-essential \
+    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
-
-COPY --from=builder /usr/local/bin/python3.11 /usr/local/bin/python3.11
-COPY --from=builder /usr/local/lib/python3.11 /usr/local/lib/python3.11
-COPY --from=builder /usr/local/lib/libpython3.11.so /usr/local/lib/libpython3.11.so
-COPY --from=builder /usr/local/lib/libpython3.11.so.1.0 /usr/local/lib/libpython3.11.so.1.0
-COPY --from=builder /app/venv /app/venv
-COPY --from=builder /app/openreview-expertise /app/openreview-expertise
-
-RUN ln -s /usr/local/bin/python3.11 /usr/local/bin/python3 \
-    && ldconfig
 
 # HuggingFace models (specter, specter2 base + adapter, scincl) are not baked into
 # the image — they are fetched from gs://openreview-expertise/expertise-utils/hf_models/


### PR DESCRIPTION
## What this changes

The Docker image and CI both pulled Python 3.11 from `ppa:deadsnakes/ppa`. When `ppa.launchpadcontent.net` had connection timeouts, the image build failed and CI was stuck on the same path. This PR removes the PPA from the entire pipeline by switching to Python 3.12, using each environment's most native source for it:

### Files changed

- **[Dockerfile](Dockerfile)** — single stage. Removes `software-properties-common` + `add-apt-repository -y ppa:deadsnakes/ppa` + `python3.11*`, replaces with a plain `apt-get install python3.12 python3.12-venv python3.12-dev` against the existing `nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04` base (3.12 is in noble's main repo).
- **[.circleci/config.yml](.circleci/config.yml)** — `PYTHON_VERSION: 3.11 → 3.12`, deadsnakes step replaced with `uv`. CircleCI machine image stays on `ubuntu-2204:2022.10.2` and resource class stays on `large` (gen2 / `ubuntu-2404` is paid-only on the open-source plan, so we can't use those). On jammy, jammy ships 3.10 in main and noble would require gen2 — so we install Python 3.12 via [`uv`](https://github.com/astral-sh/uv) instead, which downloads a prebuilt CPython from python-build-standalone in seconds. Venv creation switches to `uv venv --python 3.12 --seed ~/venv` (the `--seed` keeps `pip`/`setuptools`/`wheel` available so the rest of the step is unchanged).
- **[.github/workflows/deploy-prod.yml](.github/workflows/deploy-prod.yml)** and **[.github/workflows/deploy-dev.yml](.github/workflows/deploy-dev.yml)** — `python-version: '3.11' → '3.12'`. `actions/setup-python@v5` handles 3.12 natively.

After this PR, no part of the pipeline (image build, CI tests, deploy workflows) depends on `ppa.launchpadcontent.net`.

## Why 3.12 instead of staying on 3.11

The original Dockerfile pinned 3.11 even though Ubuntu 24.04 (the CUDA base image's OS) ships 3.12 — that mismatch is what forced the PPA in the first place. There's no project-level reason to stay on 3.11: [setup.py](setup.py) doesn't set `python_requires`, and openreview-py already runs its full test suite on 3.13, so 3.12 is well within the supported range.

Audited for known 3.12 breaking changes:
- `distutils` was removed in 3.12 → no occurrences in the source tree.
- `imp` was removed in 3.12 → no occurrences either.

Direct dependencies in [setup.py](setup.py) (numpy, scipy, torch, spacy 3.8, gensim 4.4, flask 3, faiss-cpu, google-cloud-*) all publish wheels for 3.12.

## Why uv (and not deadsnakes 3.12) for CircleCI

We can't move the CircleCI machine image to `ubuntu-2404` because that requires the `gen2` resource pool, which is paid-only on this project's open-source plan. Staying on `ubuntu-2204` means jammy, where Python 3.12 isn't in the default repos — so installing it natively is not an option. The two remaining choices were:

1. Keep deadsnakes (now installing 3.12 instead of 3.11) — same Launchpad SPOF that motivated this PR.
2. Use `uv python install 3.12`, which downloads a prebuilt CPython from python-build-standalone via `astral.sh` — different CDN, no PPA, no apt repo, fast.

Option 2 fully removes the deadsnakes dependency from CI. `uv` itself is installed via a single `curl | sh` and only used to provide Python and create the venv; the rest of the job (`pip install`, `pytest`, etc.) is unchanged.

## Test plan

- [ ] `docker build -t openreview-expertise:test .` succeeds without contacting `ppa.launchpadcontent.net`.
- [ ] `docker run --rm openreview-expertise:test python -c "import sys; print(sys.version)"` prints 3.12.x.
- [ ] `docker run --rm openreview-expertise:test python -c "import torch, faiss, expertise; print(torch.__version__)"` succeeds (catches any 3.12 / wheel / native-lib gap).
- [ ] Smoke-test the entrypoint — service starts and `/health` responds.
- [ ] CircleCI: full job passes. The new `uv` install step succeeds, `python --version` prints 3.12.x, and the existing `pip install -e '.[dev]'` flow works against the uv-seeded venv.
- [ ] Both deploy workflows run end-to-end on a dev branch (image build + Vertex pipeline build).
