### PR TITLE
Include `publications_by_profile_id.json` in the dataset tarball

### DIFF
--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -960,7 +960,7 @@ class GCPInterface(object):
         blob_name = f"{folder_path}/dataset.tar.gz"
         dataset_gcs_path = f"gs://{self.bucket_name}/{blob_name}"
 
-        dataset_items = ['archives', 'submissions', 'submissions.json', 'metadata.json']
+        dataset_items = ['archives', 'submissions', 'submissions.json', 'metadata.json', 'publications_by_profile_id.json']
         items_to_pack = [item for item in dataset_items if os.path.exists(os.path.join(job_dir, item))]
 
         if not items_to_pack:

--- a/tests/test_gcp_interface.py
+++ b/tests/test_gcp_interface.py
@@ -419,6 +419,10 @@ def test_upload_dataset(mock_storage_client, openreview_client):
         with open(os.path.join(job_dir, 'metadata.json'), 'w') as f:
             json.dump({'submission_count': 1, 'archives_count': 2}, f)
 
+        # Group-group jobs produce this file; aggregate_by_group reads it after extraction.
+        with open(os.path.join(job_dir, 'publications_by_profile_id.json'), 'w') as f:
+            json.dump({'~User_One1': [{'id': 'paper1'}]}, f)
+
         config = JobConfig(job_id='test-upload-job', job_dir=job_dir)
 
         result = gcp_interface.upload_dataset(config)
@@ -439,12 +443,14 @@ def test_upload_dataset(mock_storage_client, openreview_client):
         assert 'submissions/sub1.jsonl' in names
         assert 'submissions.json' in names
         assert 'metadata.json' in names
+        assert 'publications_by_profile_id.json' in names
 
         # Source files in job_dir are removed after a successful upload
         assert not os.path.exists(archives_dir)
         assert not os.path.exists(submissions_dir)
         assert not os.path.exists(os.path.join(job_dir, 'submissions.json'))
         assert not os.path.exists(os.path.join(job_dir, 'metadata.json'))
+        assert not os.path.exists(os.path.join(job_dir, 'publications_by_profile_id.json'))
 
 
 # Test that upload_dataset uses the provided vertex_id as the folder name,


### PR DESCRIPTION
## What this fixes

Group-group expertise jobs were failing in the Vertex AI pipeline with `FileNotFoundError` on `publications_by_profile_id.json` inside `aggregate_by_group` ([utils/utils.py:531](expertise/utils/utils.py#L531)).

The dataset tarball built in stage 1 and consumed in stage 2 uses a hardcoded allowlist at [expertise/service/utils.py:963](expertise/service/utils.py#L963), and that file wasn't on it. It's the only file `create_dataset` produces that wasn't being packed; group-group is the only path that produces *and* requires it, so that path was broken 100% while other jobs were unaffected.

Regression introduced in #366 when dataset creation and execution were split across workers.

## The fix

Add `publications_by_profile_id.json` to `dataset_items`. The existing `os.path.exists` filter on the next line means non-group-group jobs (which never write the file) are unaffected.

## Test

Extended [`test_upload_dataset`](tests/test_gcp_interface.py#L377) to stage the file, assert it ends up in the tar archive, and assert it's cleaned up from the job dir after upload. Verified the new assertion fails without the fix and passes with it.

## Test plan

- [ ] `pytest tests/test_gcp_interface.py::test_upload_dataset` passes.
- [ ] End-to-end group-group job on dev completes without the `FileNotFoundError`.