### PR TITLE
Pin and verify the `uv` install in CI instead of `curl | sh`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,18 @@ jobs:
             sudo env $APT_OPTS TZ=Etc/UTC apt-get install -y tzdata
             # uv ships prebuilt CPython (python-build-standalone), so we get
             # ${PYTHON_VERSION} without depending on ppa:deadsnakes.
-            curl -LsSf https://astral.sh/uv/install.sh | sh
+            # Pinned + SHA-256 verified (no `curl | sh` from astral.sh).
+            # On version bump, also update UV_SHA256 to match the new tarball;
+            # the canonical checksum lives at:
+            # https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz.sha256
+            UV_VERSION="0.11.9"
+            UV_SHA256="5c43f82077ff0cd5aec588286cbabd89913e4d045bd4e8aa60b20b3ecffc36e3"
+            UV_TARBALL="uv-x86_64-unknown-linux-gnu.tar.gz"
+            curl -fsSL --proto '=https' --tlsv1.2 -o "/tmp/${UV_TARBALL}" \
+              "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_TARBALL}"
+            echo "${UV_SHA256}  /tmp/${UV_TARBALL}" | sha256sum -c -
+            mkdir -p "$HOME/.local/bin"
+            tar -xzf "/tmp/${UV_TARBALL}" -C "$HOME/.local/bin" --strip-components=1
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
             export PATH="$HOME/.local/bin:$PATH"
             uv python install ${PYTHON_VERSION}


### PR DESCRIPTION
## What changed

Addresses @tyler-dominguez's review feedback on #368. The `uv` install step in [.circleci/config.yml](.circleci/config.yml) no longer pipes `astral.sh/uv/install.sh` straight into a shell. Instead it:

- pulls a pinned release tarball from `github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz`,
- verifies it against a hardcoded `UV_SHA256` with `sha256sum -c -`,
- extracts the binary into `$HOME/.local/bin`.

`curl` is also tightened with `--proto '=https' --tlsv1.2`.

## Why

`curl | sh` from a third-party host runs whatever bytes `astral.sh` serves at install time, with no integrity check — a CDN compromise or MITM would land arbitrary code in CI. The pinned-tarball + SHA256 approach gives us a checksum we control, fetched from GitHub's release storage, and a fixed `uv` version we can audit and bump deliberately.

## Bumping `uv`

Both `UV_VERSION` and `UV_SHA256` need to move together. The canonical checksum for a release lives at:

```
https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz.sha256
```

There's a comment in the config block pointing at this so the next person bumping `uv` doesn't miss it.

## Test plan

- [ ] CircleCI job passes with the new install step (download + checksum verify + extract all succeed).
- [ ] `uv --version` in the build log prints `0.11.9`.
- [ ] `python --version` still prints 3.12.x and the rest of the job is unchanged.