### PR TITLE
Stream sparse score generation from CSV

### DIFF
--- a/expertise/execute_expertise.py
+++ b/expertise/execute_expertise.py
@@ -3,7 +3,7 @@ import openreview, os, json, csv
 from .create_dataset import OpenReviewExpertise
 from .dataset import ArchivesDataset, SubmissionsDataset, BidsDataset
 from .config import ModelConfig
-from .utils.utils import aggregate_by_group, generate_sparse_scores
+from .utils.utils import aggregate_by_group, generate_sparse_scores, generate_sparse_scores_streaming
 
 # Move run.py functionality to a function that accepts a config dict
 def execute_expertise(config):
@@ -221,14 +221,13 @@ def execute_expertise(config):
         )
 
     if 'alternate_match_group' in config.keys():
-        preliminary_scores = aggregate_by_group(config)
-    else:
-        preliminary_scores = predictor.preliminary_scores
+        aggregate_by_group(config)
 
     if config['model_params'].get('sparse_value'):
         sparse_value = config['model_params']['sparse_value']
-        scores_path = Path(config['model_params']['scores_path']).joinpath(config['name'] + '_sparse.csv')
-        generate_sparse_scores(preliminary_scores, sparse_value, scores_path)
+        full_csv_path = Path(config['model_params']['scores_path']).joinpath(config['name'] + '.csv')
+        sparse_csv_path = Path(config['model_params']['scores_path']).joinpath(config['name'] + '_sparse.csv')
+        generate_sparse_scores_streaming(full_csv_path, sparse_value, sparse_csv_path)
 
 def execute_create_dataset(client_v2, config=None):
 

--- a/expertise/utils/utils.py
+++ b/expertise/utils/utils.py
@@ -505,6 +505,49 @@ def generate_sparse_scores(full_scores, sparse_value, scores_path=None):
 
     return sparse_scores
 
+def generate_sparse_scores_streaming(input_csv_path, sparse_value, output_csv_path):
+    # Streaming counterpart to generate_sparse_scores. Reads the full scores
+    # CSV once, keeping a per-note_id and per-profile_id min-heap of size
+    # sparse_value (heap key = score). Memory is bounded by
+    # (num_notes + num_profiles) * sparse_value instead of the full
+    # paper_num_test * num_reviewers cross product.
+    import heapq
+
+    note_heaps = {}
+    profile_heaps = {}
+
+    print('Scanning scores...')
+    with open(input_csv_path, 'r') as f:
+        reader = csv.reader(f)
+        for row in reader:
+            note_id, profile_id, score_str = row[0], row[1], row[2]
+            score = float(score_str)
+            entry = (score, note_id, profile_id)
+
+            for key, heaps in ((note_id, note_heaps), (profile_id, profile_heaps)):
+                heap = heaps.get(key)
+                if heap is None:
+                    heaps[key] = [entry]
+                elif len(heap) < sparse_value:
+                    heapq.heappush(heap, entry)
+                elif score > heap[0][0]:
+                    heapq.heapreplace(heap, entry)
+
+    print('Combining sparse heaps...')
+    sparse_scores = set()
+    for heaps in (note_heaps, profile_heaps):
+        for heap in heaps.values():
+            for score, note_id, profile_id in heap:
+                sparse_scores.add((note_id, profile_id, score))
+
+    print('Final Sort...')
+    sparse_scores = sorted(sparse_scores, key=lambda x: (x[0], x[2]), reverse=True)
+    with open(output_csv_path, 'w') as f:
+        for note_id, profile_id, score in sparse_scores:
+            f.write('{0},{1},{2}\n'.format(note_id, profile_id, score))
+
+    return sparse_scores
+
 def aggregate_by_group(config):
     # Fetch scores
     scores = {}


### PR DESCRIPTION
## Summary

Replace the in-memory sort-twice over `predictor.preliminary_scores` in `generate_sparse_scores` with a single CSV pass that uses per-id min-heaps to keep top-`sparse_value` scores per `note_id` and per `profile_id`.

Closes #376.

## Changes

**`expertise/utils/utils.py`**
- New `generate_sparse_scores_streaming(input_csv_path, sparse_value, output_csv_path)`. Reads the full scores CSV row-by-row; for each row, pushes onto two `heapq` min-heaps (one per `note_id`, one per `profile_id`), each bounded at `sparse_value` via `heappushpop`. After streaming, unions the heap contents into a `set` and writes the sparse CSV in the same `(note_id, score)`-descending order as the original function.
- Original `generate_sparse_scores` left intact — `tests/test_specter2scincl.py` and `tests/test_spectermfr.py` import it directly.

**`expertise/execute_expertise.py`**
- Switch the post-`all_scores` sparse step to call `generate_sparse_scores_streaming` against the on-disk CSV (`{name}.csv`) instead of `predictor.preliminary_scores`. The `aggregate_by_group` branch still runs (it overwrites that same CSV in place), so the streaming function reads the aggregated scores in that case.
- `preliminary_scores` is no longer referenced from this caller; the predictor still populates it, but its only consumer here is gone.

## Why

For a recent large job, `predictor.preliminary_scores` reached 1,112,927,340 tuples (~80 GB of Python objects). The previous `generate_sparse_scores` sorted that list in place twice; the trace showed the sort phase running from `02:46:20 Sorting...` to `07:50:03 Sort 2 complete` — about five hours of sorting a Python list, on top of the ~80 GB it occupied throughout. Combined with the matching cost in `execute_pipeline.py`'s upload step, this contributed to the OOM kill at the end of the job.

The streaming version reads from the CSV that `predictor.all_scores` already wrote and never materializes the full cross product. Memory bound is `O((num_notes + num_profiles) * sparse_value)` instead of `O(paper_num_test * num_reviewers)`.

## Test plan

- [ ] CI green (existing tests still call the original `generate_sparse_scores`).
- [ ] Smoke test: streaming and in-memory variants produce identical output sets on synthetic input (verified locally with 20 notes × 50 profiles, sparse_value=5).
- [ ] End-to-end on a real expertise job with `sparse_value` set: `*_sparse.csv` is written and matches the previous shape.