### PR TITLE
Upload embedding files directly to GCS

### DIFF
--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -265,21 +265,16 @@ def run_pipeline(
                 contents = '\n'.join([json.dumps(r) for r in result])
                 blob.upload_from_string(contents)
 
-        # Always dump embeddings to bucket
+        # Always dump embeddings to bucket. Source jsonl already has exactly
+        # {'paper_id', 'embedding'} (see Predictor._build_embedding_jsonl), so
+        # there's nothing to transform — upload the file directly via a
+        # resumable upload to avoid loading 500k embeddings (~12GB of Python
+        # objects) into memory just to re-serialize them.
         print("Dumping embeddings", flush=True)
         for emb_file in [d for d in os.listdir(config.job_dir) if '.jsonl' in d]:
-            result = []
             destination_blob = f"{blob_prefix}/{emb_file}"
-            with open(os.path.join(config.job_dir, emb_file), 'r') as f:
-                for line in f:
-                    data = json.loads(line)
-                    result.append({
-                        'paper_id': data['paper_id'],
-                        'embedding': data['embedding']
-                    })
             blob = bucket.blob(destination_blob)
-            contents = '\n'.join([json.dumps(r) for r in result])
-            blob.upload_from_string(contents)
+            blob.upload_from_filename(os.path.join(config.job_dir, emb_file))
 
     except Exception as e:
         # Write error to single JSONL line in GCS if bucket is available

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='openreview-expertise',
-    version='2.2.0',
+    version='2.2.1',
     description='OpenReview paper-reviewer affinity modeling',
     url='https://github.com/openreview/openreview-expertise',
     author='OpenReview',


### PR DESCRIPTION
## Summary

Replaces the load-into-memory + re-serialize + `upload_from_string` pattern in the embeddings dump with a direct `blob.upload_from_filename` call. The source `.jsonl` files already have exactly the destination schema (`{paper_id, embedding}` produced by `Predictor._build_embedding_jsonl`), so the previous parse-and-rejoin step was a no-op transformation that just burned RAM and CPU.

Plus a small follow-up version bump.

## Changes

### 1. Direct upload for embedding files ([0d92ecf](../commit/0d92ecf))

**File:** `expertise/execute_pipeline.py`

Before:

```python
for emb_file in [d for d in os.listdir(config.job_dir) if '.jsonl' in d]:
    result = []
    destination_blob = f"{blob_prefix}/{emb_file}"
    with open(os.path.join(config.job_dir, emb_file), 'r') as f:
        for line in f:
            data = json.loads(line)
            result.append({
                'paper_id': data['paper_id'],
                'embedding': data['embedding']
            })
    blob = bucket.blob(destination_blob)
    contents = '\n'.join([json.dumps(r) for r in result])
    blob.upload_from_string(contents)
```

After:

```python
for emb_file in [d for d in os.listdir(config.job_dir) if '.jsonl' in d]:
    destination_blob = f"{blob_prefix}/{emb_file}"
    blob = bucket.blob(destination_blob)
    blob.upload_from_filename(os.path.join(config.job_dir, emb_file))
```

`upload_from_filename` uses a resumable upload internally with a bounded chunk buffer.

### 2. Version bump 2.1.9 → 2.2.0 ([f992c0b](../commit/f992c0b))

**File:** `setup.py`

## Memory impact

For a `specter2+scincl` job with 500k publications + 35k submissions, four `.jsonl` files end up at top-level in `config.job_dir`:

| File | Rows | Old peak (Python heap) | New peak |
|---|---|---|---|
| `pub2vec_specter.jsonl` | 500k pubs | ~18 GB | ~40 MB (resumable-upload buffer) |
| `pub2vec_scincl.jsonl` | 500k pubs | ~18 GB | ~40 MB |
| `sub2vec_specter.jsonl` | 35k subs | ~1.3 GB | ~40 MB |
| `sub2vec_scincl.jsonl` | 35k subs | ~1.3 GB | ~40 MB |

Files were processed sequentially so 18 GB was the per-iteration peak (Python GC reclaimed between files) — fine on `n1-highmem-96` with 624 GB RAM, painful on smaller tiers, and just wasteful in general.

Plus a wall-time win: no JSON parse → list-of-dicts → JSON serialize → join round-trip. Disk → resumable-upload buffer → GCS is now bandwidth-bound (network) rather than CPU-bound (re-serializing 500k Python lists of 768 floats each).

## Behavior preserved

The destination blob name and contents are byte-identical to before. Each `pub2vec_*.jsonl` file contains both **cached** embeddings (kept verbatim from the cache via `_load_cached_publication_embeddings` to avoid float-precision loss on re-serialization) and **newly computed** embeddings (produced by `Predictor._build_embedding_jsonl`). Both follow the same `{paper_id, embedding}` schema, so the upload path doesn't need to distinguish them. Submission files contain only newly computed embeddings (no submission cache).

## Test plan

- [ ] `tests/test_pipeline.py::test_run_pipeline` — already pre-creates a `pub2vec.jsonl` fixture, asserts the blob exists in GCS post-pipeline, downloads it, and verifies `{paper_id, embedding}` parses correctly. Same coverage applies to `test_run_pipeline_gcsdir` and `test_run_pipeline_group`. Needs CI's GCS credentials.
- [ ] Mock-based suites unchanged: `pytest tests/test_specter2scincl.py tests/test_spectermfr.py tests/test_scoring_precision.py tests/test_gcp_interface.py` (37 passed locally).
