### PR TITLE
Pull CUDA base image from Artifact Registry instead of Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,11 @@ jobs:
       - run:
           name: Build and test container locally
           command: |
+            # Authenticate Docker to Artifact Registry so the Dockerfile FROM
+            # can pull from us-docker.pkg.dev instead of Docker Hub. gcloud is
+            # already authenticated earlier via gcp-cli/setup (OIDC).
+            gcloud auth configure-docker us-docker.pkg.dev --quiet
+
             # Build image locally (no push)
             echo "Building Docker image locally..."
             docker build -t expertise-test:${CIRCLE_SHA1:0:12} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04
+FROM us-docker.pkg.dev/sunlit-realm-131518/openreview-images/cuda:12.6.3-cudnn-runtime-ubuntu24.04
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
Switches the CircleCI container build to pull the CUDA base image from our Google Artifact Registry mirror instead of Docker Hub, eliminating CI flakes from Docker Hub rate limits.

## Changes
- **`Dockerfile`**: `FROM` now points at `us-docker.pkg.dev/sunlit-realm-131518/openreview-images/cuda:12.6.3-cudnn-runtime-ubuntu24.04` instead of `nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04`.
- **`.circleci/config.yml`**: In the "Build and test container locally" step, run `gcloud auth configure-docker us-docker.pkg.dev --quiet` before `docker build` so Docker can authenticate to AR via the OIDC-authenticated `gcloud` set up earlier in the job.

## Prerequisite
The service account bound to CircleCI's workload identity pool needs `roles/artifactregistry.reader` on the `openreview-images` repo in `sunlit-realm-131518`. Without it, the build will fail with a 403 on the first pull.