### PR TITLE
Score matrix refactor + CSV-everywhere storage + format=csv API option

### DIFF
--- a/expertise/execute_expertise.py
+++ b/expertise/execute_expertise.py
@@ -220,32 +220,30 @@ def execute_expertise(config):
             scores_path=Path(config['model_params']['scores_path']).joinpath(config['name'] + '.csv')
         )
 
-    # Sparse-score dispatch.
+    # Sparse-score dispatch. sparse_value is a required positive integer (the
+    # config layer validates and defaults it), so we can rely on it being
+    # set and > 0 here.
     #  - alternate_match_group: aggregate_by_group emits a tuple list; use legacy
     #    generate_sparse_scores (tuple-based sort) on it.
     #  - Predictors that expose a score matrix (specter2 / scincl / specter2+scincl):
     #    generate sparse directly from the matrix via torch.topk.
     #  - Legacy predictors that only expose preliminary_scores (bm25, mfr,
     #    specter+mfr): keep the tuple-based path.
+    sparse_value = config['model_params']['sparse_value']
+    sparse_path = Path(config['model_params']['scores_path']).joinpath(config['name'] + '_sparse.csv')
     if 'alternate_match_group' in config.keys():
         preliminary_scores = aggregate_by_group(config)
-        if config['model_params'].get('sparse_value'):
-            sparse_value = config['model_params']['sparse_value']
-            sparse_path = Path(config['model_params']['scores_path']).joinpath(config['name'] + '_sparse.csv')
-            generate_sparse_scores(preliminary_scores, sparse_value, sparse_path)
-    elif config['model_params'].get('sparse_value'):
-        sparse_value = config['model_params']['sparse_value']
-        sparse_path = Path(config['model_params']['scores_path']).joinpath(config['name'] + '_sparse.csv')
-        if getattr(predictor, 'scores_matrix', None) is not None:
-            generate_sparse_scores_from_matrix(
-                predictor.scores_matrix,
-                predictor.test_id_list,
-                predictor.reviewer_ids,
-                sparse_value,
-                sparse_path,
-            )
-        else:
-            generate_sparse_scores(predictor.preliminary_scores, sparse_value, sparse_path)
+        generate_sparse_scores(preliminary_scores, sparse_value, sparse_path)
+    elif getattr(predictor, 'scores_matrix', None) is not None:
+        generate_sparse_scores_from_matrix(
+            predictor.scores_matrix,
+            predictor.test_id_list,
+            predictor.reviewer_ids,
+            sparse_value,
+            sparse_path,
+        )
+    else:
+        generate_sparse_scores(predictor.preliminary_scores, sparse_value, sparse_path)
 
 def execute_create_dataset(client_v2, config=None):
 

--- a/expertise/execute_expertise.py
+++ b/expertise/execute_expertise.py
@@ -3,7 +3,7 @@ import openreview, os, json, csv
 from .create_dataset import OpenReviewExpertise
 from .dataset import ArchivesDataset, SubmissionsDataset, BidsDataset
 from .config import ModelConfig
-from .utils.utils import aggregate_by_group, generate_sparse_scores
+from .utils.utils import aggregate_by_group, generate_sparse_scores, generate_sparse_scores_from_matrix
 
 # Move run.py functionality to a function that accepts a config dict
 def execute_expertise(config):
@@ -97,7 +97,7 @@ def execute_expertise(config):
             scincl_publications_path=scincl_publication_path,
             specter_submissions_path=Path(config['model_params']['submissions_path']).joinpath('sub2vec_specter.jsonl'),
             scincl_submissions_path=Path(config['model_params']['submissions_path']).joinpath('sub2vec_scincl.jsonl'),
-            scores_path=Path(config['model_params']['scores_path']).joinpath(config['name'] + '.csv')
+            matrix_path=Path(config['model_params']['scores_path']).joinpath(config['name'] + '.pt')
         )
 
     if config['model'] == 'scincl':
@@ -127,7 +127,7 @@ def execute_expertise(config):
         predictor.all_scores(
             scincl_publication_path,
             Path(config['model_params']['submissions_path']).joinpath('sub2vec.jsonl'),
-            Path(config['model_params']['scores_path']).joinpath(config['name'] + '.csv'),
+            Path(config['model_params']['scores_path']).joinpath(config['name'] + '.pt'),
             p2p_path=Path(config['model_params']['scores_path']).joinpath(config['name'] + '_p2p' + '.json')
         )
 
@@ -158,7 +158,7 @@ def execute_expertise(config):
         predictor.all_scores(
             specter_publication_path,
             Path(config['model_params']['submissions_path']).joinpath('sub2vec.jsonl'),
-            Path(config['model_params']['scores_path']).joinpath(config['name'] + '.csv'),
+            Path(config['model_params']['scores_path']).joinpath(config['name'] + '.pt'),
             p2p_path=Path(config['model_params']['scores_path']).joinpath(config['name'] + '_p2p' + '.json')
         )
 
@@ -220,15 +220,32 @@ def execute_expertise(config):
             scores_path=Path(config['model_params']['scores_path']).joinpath(config['name'] + '.csv')
         )
 
+    # Sparse-score dispatch.
+    #  - alternate_match_group: aggregate_by_group emits a tuple list; use legacy
+    #    generate_sparse_scores (tuple-based sort) on it.
+    #  - Predictors that expose a score matrix (specter2 / scincl / specter2+scincl):
+    #    generate sparse directly from the matrix via torch.topk.
+    #  - Legacy predictors that only expose preliminary_scores (bm25, mfr,
+    #    specter+mfr): keep the tuple-based path.
     if 'alternate_match_group' in config.keys():
         preliminary_scores = aggregate_by_group(config)
-    else:
-        preliminary_scores = predictor.preliminary_scores
-
-    if config['model_params'].get('sparse_value'):
+        if config['model_params'].get('sparse_value'):
+            sparse_value = config['model_params']['sparse_value']
+            sparse_path = Path(config['model_params']['scores_path']).joinpath(config['name'] + '_sparse.csv')
+            generate_sparse_scores(preliminary_scores, sparse_value, sparse_path)
+    elif config['model_params'].get('sparse_value'):
         sparse_value = config['model_params']['sparse_value']
-        scores_path = Path(config['model_params']['scores_path']).joinpath(config['name'] + '_sparse.csv')
-        generate_sparse_scores(preliminary_scores, sparse_value, scores_path)
+        sparse_path = Path(config['model_params']['scores_path']).joinpath(config['name'] + '_sparse.csv')
+        if getattr(predictor, 'scores_matrix', None) is not None:
+            generate_sparse_scores_from_matrix(
+                predictor.scores_matrix,
+                predictor.test_id_list,
+                predictor.reviewer_ids,
+                sparse_value,
+                sparse_path,
+            )
+        else:
+            generate_sparse_scores(predictor.preliminary_scores, sparse_value, sparse_path)
 
 def execute_create_dataset(client_v2, config=None):
 

--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -207,12 +207,12 @@ def run_pipeline(
         paper_paper_matching = validated_request.entityA.get('type', '') == 'Note' and \
             validated_request.entityB.get('type', '') == 'Note'
 
-        # Stream-convert score CSVs to JSONL directly into the GCS upload
-        # stream. Avoids loading the full result set (potentially 100M+ rows)
-        # into a Python list before serializing — that path peaked at ~95 GB
-        # of host memory for large jobs and triggered OOM kills.
+        # Stream-convert the (sparse) score CSV to JSONL directly into the
+        # GCS upload stream. The full score table is no longer emitted as a
+        # CSV at all — it's saved as a torch tensor in the .pt file uploaded
+        # below — so the only CSV here is the sparse one.
         print("Converting CSV scores to JSONL...", flush=True)
-        for csv_file in [d for d in os.listdir(config.job_dir) if '.csv' in d]:
+        for csv_file in [d for d in os.listdir(config.job_dir) if d.endswith('.csv')]:
             dest_name = 'scores_sparse.jsonl' if '_sparse' in csv_file else 'scores.jsonl'
             destination_blob = f"{blob_prefix}/{dest_name}"
             blob = bucket.blob(destination_blob)
@@ -231,6 +231,15 @@ def run_pipeline(
                     out.write(json.dumps(obj))
                     first = False
         print("Finished writing scores to JSONL", flush=True)
+
+        # Upload the full scores matrix (.pt) directly. Same direct-streaming
+        # pattern as the embedding files — source bytes go disk → resumable-
+        # upload buffer → GCS without ever being parsed in Python.
+        print("Dumping scores matrix(es)", flush=True)
+        for pt_file in [d for d in os.listdir(config.job_dir) if d.endswith('.pt')]:
+            destination_blob = f"{blob_prefix}/{pt_file}"
+            blob = bucket.blob(destination_blob)
+            blob.upload_from_filename(os.path.join(config.job_dir, pt_file))
 
         # Dump config
         print("Dumping job config", flush=True)

--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -207,30 +207,21 @@ def run_pipeline(
         paper_paper_matching = validated_request.entityA.get('type', '') == 'Note' and \
             validated_request.entityB.get('type', '') == 'Note'
 
-        # Stream-convert the (sparse) score CSV to JSONL directly into the
-        # GCS upload stream. The full score table is no longer emitted as a
-        # CSV at all — it's saved as a torch tensor in the .pt file uploaded
-        # below — so the only CSV here is the sparse one.
-        print("Converting CSV scores to JSONL...", flush=True)
+        # Upload the score CSV(s) to GCS as-is (no transformation). The CSV
+        # rows are in the model's natural order: [test_id, reviewer_id, score]
+        # for mixed Group/Note matching; [test_id, train_id, score] for
+        # symmetric matching. The matching-type-aware entityA/entityB swap
+        # happens at read time in both the local and cloud reader paths,
+        # consistent with how ExpertiseService.get_expertise_results has
+        # always handled it.
+        print("Uploading score CSV(s)...", flush=True)
         for csv_file in [d for d in os.listdir(config.job_dir) if d.endswith('.csv')]:
-            dest_name = 'scores_sparse.jsonl' if '_sparse' in csv_file else 'scores.jsonl'
+            dest_name = 'scores_sparse.csv' if '_sparse' in csv_file else 'scores.csv'
             destination_blob = f"{blob_prefix}/{dest_name}"
             blob = bucket.blob(destination_blob)
             src = os.path.join(config.job_dir, csv_file)
-
-            with blob.open('w') as out, open(src, 'r') as f:
-                reader = csv.reader(f)
-                first = True
-                for row in reader:
-                    if group_group_matching or paper_paper_matching:
-                        obj = {'entityA': row[0], 'entityB': row[1], 'score': float(row[2])}
-                    else:
-                        obj = {'entityB': row[0], 'entityA': row[1], 'score': float(row[2])}
-                    if not first:
-                        out.write('\n')
-                    out.write(json.dumps(obj))
-                    first = False
-        print("Finished writing scores to JSONL", flush=True)
+            blob.upload_from_filename(src)
+        print("Finished uploading score CSV(s)", flush=True)
 
         # Upload the full scores matrix (.pt) directly. Same direct-streaming
         # pattern as the embedding files — source bytes go disk → resumable-

--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -202,10 +202,6 @@ def run_pipeline(
 
         # Fetch and write to storage
         print('Fetching and writing to storage')
-        group_group_matching = validated_request.entityA.get('type', '') == 'Group' and \
-            validated_request.entityB.get('type', '') == 'Group'
-        paper_paper_matching = validated_request.entityA.get('type', '') == 'Note' and \
-            validated_request.entityB.get('type', '') == 'Note'
 
         # Upload the score CSV(s) to GCS as-is (no transformation). The CSV
         # rows are in the model's natural order: [test_id, reviewer_id, score]

--- a/expertise/execute_pipeline.py
+++ b/expertise/execute_pipeline.py
@@ -16,7 +16,7 @@ DEFAULT_CONFIG = {
     "model": "specter+mfr",
     "model_params": {
         "use_title": True,
-        "sparse_value": 600,
+        "sparse_value": 400,
         "specter_batch_size": 16,
         "mfr_batch_size": 50,
         "use_abstract": True,

--- a/expertise/models/specter2_scincl/ensemble.py
+++ b/expertise/models/specter2_scincl/ensemble.py
@@ -1,4 +1,5 @@
 import os
+import torch
 
 from .specter import Specter2Predictor
 from .scincl import SciNCLPredictor
@@ -45,7 +46,9 @@ class EnsembleModel:
         self.merge_alpha = merge_alpha
         self.sparse_value = sparse_value
         self.normalize_scores = normalize_scores
-        self.preliminary_scores = None
+        self.scores_matrix = None
+        self.test_id_list = None
+        self.reviewer_ids = None
 
     def set_archives_dataset(self, archives_dataset):
         print("Setting SPECTER archives")
@@ -75,36 +78,48 @@ class EnsembleModel:
 
     def all_scores(self, specter_publications_path=None, scincl_publications_path=None,
                    specter_submissions_path=None, scincl_submissions_path=None,
-                   scores_path=None):
-        print("SPECTER:")
-        specter_scores_path = os.path.join(self.specter_predictor.work_dir, "specter_affinity.csv")
-        self.specter_predictor.all_scores(specter_publications_path, specter_submissions_path, specter_scores_path)
-        print("SciNCL:")
-        scincl_scores_path = os.path.join(self.scincl_predictor.work_dir, "scincl_affinity.csv")
-        self.scincl_predictor.all_scores(scincl_publications_path, scincl_submissions_path, scincl_scores_path)
+                   matrix_path=None):
+        print("SPECTER:", flush=True)
+        # Components compute their score matrix in memory; we don't persist
+        # per-component matrices to disk (matrix_path=None) because the
+        # ensemble only needs the merged result for downstream consumers.
+        self.specter_predictor.all_scores(
+            publications_path=specter_publications_path,
+            submissions_path=specter_submissions_path,
+            matrix_path=None,
+        )
+        print("SciNCL:", flush=True)
+        self.scincl_predictor.all_scores(
+            publications_path=scincl_publications_path,
+            submissions_path=scincl_submissions_path,
+            matrix_path=None,
+        )
 
-        # Convert preliminary scores of SPECTER to a dictionary
-        csv_scores = []
-        self.preliminary_scores = []
-        specter_preliminary_scores_map = {}
-        for entry in self.specter_predictor.preliminary_scores:
-            specter_preliminary_scores_map[(entry[0], entry[1])] = entry[2]
+        # Matrix-level merge replaces the per-tuple merge that previously
+        # iterated ~175M (test, reviewer) pairs in Python. The two component
+        # matrices share row/col ordering because both predictors were fed
+        # the same archives/submissions datasets.
+        print("EnsembleModel: matrix-level merge...", flush=True)
+        specter_m = self.specter_predictor.scores_matrix
+        scincl_m = self.scincl_predictor.scores_matrix
+        merged = specter_m * self.merge_alpha + scincl_m * (1 - self.merge_alpha)
+        if self.normalize_scores:
+            merged = torch.clamp(merged, 0.0, 1.0)
+        else:
+            merged = torch.clamp(merged, -1.0, 1.0)
+        # Round once, vectorized — matches the previous per-row round(..., 4).
+        merged = (merged * 10000).round() / 10000
 
-        for entry in self.scincl_predictor.preliminary_scores:
-            new_score = specter_preliminary_scores_map[(entry[0], entry[1])] * self.merge_alpha + \
-                        entry[2] * (1 - self.merge_alpha)
-            if self.normalize_scores:
-                new_score = round(min(1.0, max(0.0, new_score)), 4)
-            else:
-                new_score = round(min(1.0, max(-1.0, new_score)), 4)
-            csv_line = '{note_id},{reviewer},{score}'.format(note_id=entry[0], reviewer=entry[1],
-                                                             score=new_score)
-            csv_scores.append(csv_line)
-            self.preliminary_scores.append((entry[0], entry[1], new_score))
+        self.scores_matrix = merged
+        self.test_id_list = self.specter_predictor.test_id_list
+        self.reviewer_ids = self.specter_predictor.reviewer_ids
 
-        if scores_path:
-            with open(scores_path, 'w') as f:
-                for csv_line in csv_scores:
-                    f.write(csv_line + '\n')
+        if matrix_path:
+            print(f"Saving ensemble scores matrix to {matrix_path}...", flush=True)
+            torch.save({
+                'scores': self.scores_matrix,
+                'test_ids': self.test_id_list,
+                'reviewer_ids': self.reviewer_ids,
+            }, matrix_path)
 
-        return self.preliminary_scores
+        return self.scores_matrix

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -55,7 +55,9 @@ class SciNCLPredictor(Predictor):
             self.cuda_device = torch.device("cuda:0")
         else:
             self.cuda_device = torch.device("cpu")
-        self.preliminary_scores = None
+        self.scores_matrix = None
+        self.test_id_list = None
+        self.reviewer_ids = None
         self.sparse_value = sparse_value
         if not os.path.exists(self.work_dir) and not os.path.isdir(self.work_dir):
             os.makedirs(self.work_dir)
@@ -210,7 +212,7 @@ class SciNCLPredictor(Predictor):
         with open(publications_path, 'w') as f:
             f.writelines(pub_jsonl)
 
-    def all_scores(self, publications_path=None, submissions_path=None, scores_path=None, p2p_path=None):
+    def all_scores(self, publications_path=None, submissions_path=None, matrix_path=None, p2p_path=None):
         def load_emb_file(emb_file, paper_id_to_weight=None):
             paper_emb_size_default = 768
             id_list = []
@@ -289,18 +291,18 @@ class SciNCLPredictor(Predictor):
             print("Skipping normalization of scores...")
         p2p_aff_norm = p2p_aff
 
-        csv_scores = []
-        self.preliminary_scores = []
-
         print("Computing scincl per-reviewer scores...", flush=True)
         if self.compute_paper_paper:
-            for i in range(paper_num_train):
-                for j in range(paper_num_test):
-                    csv_line = '{match_id},{submission_id},{score}'.format(match_id=test_id_list[j], submission_id=train_id_list[i],
-                                                                    score=round(p2p_aff_norm[j, i].item(), 4))
-                    csv_scores.append(csv_line)
-                    self.preliminary_scores.append((test_id_list[j], train_id_list[i], round(p2p_aff_norm[j, i].item(), 4)))
+            # Paper-paper similarity: matrix IS the full p2p_aff_norm.
+            # Column ids are train paper ids (not reviewer ids).
+            # TODO: at very large scale (e.g. 35k x 500k = ~70GB) this tensor
+            # won't fit in memory for torch.save; needs chunked save.
+            self.scores_matrix = p2p_aff_norm
+            self.test_id_list = test_id_list
+            self.reviewer_ids = train_id_list
         else:
+            score_vectors = []
+            reviewer_ids = []
             for reviewer_id, train_note_id_list in self.pub_author_ids_to_note_id.items():
                 if len(train_note_id_list) == 0:
                     continue
@@ -325,27 +327,34 @@ class SciNCLPredictor(Predictor):
                     # q=0.5 (percentile_select=50) -> median score
                     # q=0.0 (percentile_select=0) -> min score
                     q = self.percentile_select / 100.0
-                    q = max(0.0, min(1.0, q)) 
+                    q = max(0.0, min(1.0, q))
                     all_paper_aff = torch.quantile(train_paper_aff_j, q, dim=1, interpolation='linear')
                 elif self.average_score:
                     all_paper_aff = train_paper_aff_j.mean(dim=1)
                 elif self.max_score:
                     all_paper_aff = train_paper_aff_j.max(dim=1)[0]
-                for j in range(paper_num_test):
-                    csv_line = '{note_id},{reviewer},{score}'.format(note_id=test_id_list[j], reviewer=reviewer_id,
-                                                                    score=round(all_paper_aff[j].item(), 4))
-                    csv_scores.append(csv_line)
-                    self.preliminary_scores.append((test_id_list[j], reviewer_id, round(all_paper_aff[j].item(), 4)))
+
+                score_vectors.append(all_paper_aff)
+                reviewer_ids.append(reviewer_id)
+
+            self.scores_matrix = torch.stack(score_vectors, dim=1)  # [num_test, num_reviewers]
+            self.test_id_list = test_id_list
+            self.reviewer_ids = reviewer_ids
+
+        # Round once, vectorized — matches the previous per-row round(..., 4).
+        self.scores_matrix = (self.scores_matrix * 10000).round() / 10000
         print(f"Computed preliminary scores for SciNCL.", flush=True)
 
-        if scores_path:
-            print(f"Writing {len(csv_scores)} scincl rows to CSV...", flush=True)
-            with open(scores_path, 'w') as f:
-                for csv_line in csv_scores:
-                    f.write(csv_line + '\n')
+        if matrix_path:
+            print(f"Saving SciNCL scores matrix to {matrix_path}...", flush=True)
+            torch.save({
+                'scores': self.scores_matrix,
+                'test_ids': self.test_id_list,
+                'reviewer_ids': self.reviewer_ids,
+            }, matrix_path)
 
         print("Done computing scincl scores.", flush=True)
-        return self.preliminary_scores
+        return self.scores_matrix
 
     def _remove_keys_from_cache(self, key):
         if self.redis:

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -337,7 +337,15 @@ class SciNCLPredictor(Predictor):
                 score_vectors.append(all_paper_aff)
                 reviewer_ids.append(reviewer_id)
 
-            self.scores_matrix = torch.stack(score_vectors, dim=1)  # [num_test, num_reviewers]
+            if score_vectors:
+                self.scores_matrix = torch.stack(score_vectors, dim=1)  # [num_test, num_reviewers]
+            else:
+                # No eligible reviewers (every train_note_id_list empty or all
+                # publications dropped via bad_id_set). Match the pre-refactor
+                # behavior: produce a 0-column matrix and empty reviewer list
+                # so downstream sparse generation / merging / CSV emission
+                # all see a well-formed but empty result instead of crashing.
+                self.scores_matrix = torch.empty((paper_num_test, 0), dtype=p2p_aff_norm.dtype)
             self.test_id_list = test_id_list
             self.reviewer_ids = reviewer_ids
 

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -310,6 +310,15 @@ class SciNCLPredictor(Predictor):
                 for paper_id in train_note_id_list:
                     if paper_id not in train_bad_id_set:
                         train_paper_idx.append(paper_id2train_idx[paper_id])
+                if not train_paper_idx:
+                    # Every publication for this reviewer had a bad embedding
+                    # (length 0, added to train_bad_id_set in load_emb_file).
+                    # Slicing with an empty column index gives a [num_test, 0]
+                    # tensor, which would crash .max(dim=1) / torch.quantile
+                    # and produce NaNs from .mean(dim=1). Skip the reviewer
+                    # consistently with the "no publications" case above —
+                    # they won't appear in self.reviewer_ids.
+                    continue
                 train_paper_aff_j = p2p_aff_norm[:, train_paper_idx]
 
                 # Apply venue-specific weights per reviewer

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -350,7 +350,15 @@ class Specter2Predictor(Predictor):
                 score_vectors.append(all_paper_aff)
                 reviewer_ids.append(reviewer_id)
 
-            self.scores_matrix = torch.stack(score_vectors, dim=1)  # [num_test, num_reviewers]
+            if score_vectors:
+                self.scores_matrix = torch.stack(score_vectors, dim=1)  # [num_test, num_reviewers]
+            else:
+                # No eligible reviewers (every train_note_id_list empty or all
+                # publications dropped via bad_id_set). Match the pre-refactor
+                # behavior: produce a 0-column matrix and empty reviewer list
+                # so downstream sparse generation / merging / CSV emission
+                # all see a well-formed but empty result instead of crashing.
+                self.scores_matrix = torch.empty((paper_num_test, 0), dtype=p2p_aff_norm.dtype)
             self.test_id_list = test_id_list
             self.reviewer_ids = reviewer_ids
 

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -323,6 +323,15 @@ class Specter2Predictor(Predictor):
                 for paper_id in train_note_id_list:
                     if paper_id not in train_bad_id_set:
                         train_paper_idx.append(paper_id2train_idx[paper_id])
+                if not train_paper_idx:
+                    # Every publication for this reviewer had a bad embedding
+                    # (length 0, added to train_bad_id_set in load_emb_file).
+                    # Slicing with an empty column index gives a [num_test, 0]
+                    # tensor, which would crash .max(dim=1) / torch.quantile
+                    # and produce NaNs from .mean(dim=1). Skip the reviewer
+                    # consistently with the "no publications" case above —
+                    # they won't appear in self.reviewer_ids.
+                    continue
                 train_paper_aff_j = p2p_aff_norm[:, train_paper_idx]
 
                 # Apply venue-specific weights per reviewer

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -60,7 +60,9 @@ class Specter2Predictor(Predictor):
             self.cuda_device = torch.device("cuda:0")
         else:
             self.cuda_device = torch.device("cpu")
-        self.preliminary_scores = None
+        self.scores_matrix = None
+        self.test_id_list = None
+        self.reviewer_ids = None
         self.sparse_value = sparse_value
         if not os.path.exists(self.work_dir) and not os.path.isdir(self.work_dir):
             os.makedirs(self.work_dir)
@@ -223,7 +225,7 @@ class Specter2Predictor(Predictor):
         with open(publications_path, 'w') as f:
             f.writelines(pub_jsonl)
 
-    def all_scores(self, publications_path=None, submissions_path=None, scores_path=None, p2p_path=None):
+    def all_scores(self, publications_path=None, submissions_path=None, matrix_path=None, p2p_path=None):
         def load_emb_file(emb_file, paper_id_to_weight=None):
             paper_emb_size_default = 768
             id_list = []
@@ -302,18 +304,18 @@ class Specter2Predictor(Predictor):
             print("Skipping normalization of scores...")
         p2p_aff_norm = p2p_aff
 
-        csv_scores = []
-        self.preliminary_scores = []
-
         print("Computing specter per-reviewer scores...", flush=True)
         if self.compute_paper_paper:
-            for i in range(paper_num_train):
-                for j in range(paper_num_test):
-                    csv_line = '{match_id},{submission_id},{score}'.format(match_id=test_id_list[j], submission_id=train_id_list[i],
-                                                                    score=round(p2p_aff_norm[j, i].item(), 4))
-                    csv_scores.append(csv_line)
-                    self.preliminary_scores.append((test_id_list[j], train_id_list[i], round(p2p_aff_norm[j, i].item(), 4)))
+            # Paper-paper similarity: matrix IS the full p2p_aff_norm.
+            # Column ids are train paper ids (not reviewer ids).
+            # TODO: at very large scale (e.g. 35k x 500k = ~70GB) this tensor
+            # won't fit in memory for torch.save; needs chunked save.
+            self.scores_matrix = p2p_aff_norm
+            self.test_id_list = test_id_list
+            self.reviewer_ids = train_id_list
         else:
+            score_vectors = []
+            reviewer_ids = []
             for reviewer_id, train_note_id_list in self.pub_author_ids_to_note_id.items():
                 if len(train_note_id_list) == 0:
                     continue
@@ -344,21 +346,28 @@ class Specter2Predictor(Predictor):
                     all_paper_aff = train_paper_aff_j.mean(dim=1)
                 elif self.max_score:
                     all_paper_aff = train_paper_aff_j.max(dim=1)[0]
-                for j in range(paper_num_test):
-                    csv_line = '{note_id},{reviewer},{score}'.format(note_id=test_id_list[j], reviewer=reviewer_id,
-                                                                    score=round(all_paper_aff[j].item(), 4))
-                    csv_scores.append(csv_line)
-                    self.preliminary_scores.append((test_id_list[j], reviewer_id, round(all_paper_aff[j].item(), 4)))
+
+                score_vectors.append(all_paper_aff)
+                reviewer_ids.append(reviewer_id)
+
+            self.scores_matrix = torch.stack(score_vectors, dim=1)  # [num_test, num_reviewers]
+            self.test_id_list = test_id_list
+            self.reviewer_ids = reviewer_ids
+
+        # Round once, vectorized — matches the previous per-row round(..., 4).
+        self.scores_matrix = (self.scores_matrix * 10000).round() / 10000
         print(f"Computed preliminary scores for SPECTER2.", flush=True)
 
-        if scores_path:
-            print(f"Writing {len(csv_scores)} specter rows to CSV...", flush=True)
-            with open(scores_path, 'w') as f:
-                for csv_line in csv_scores:
-                    f.write(csv_line + '\n')
+        if matrix_path:
+            print(f"Saving SPECTER2 scores matrix to {matrix_path}...", flush=True)
+            torch.save({
+                'scores': self.scores_matrix,
+                'test_ids': self.test_id_list,
+                'reviewer_ids': self.reviewer_ids,
+            }, matrix_path)
 
         print("Done computing specter scores.", flush=True)
-        return self.preliminary_scores
+        return self.scores_matrix
 
     def _remove_keys_from_cache(self, key):
         if self.redis:

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -390,11 +390,19 @@ class BaseExpertiseService:
         with open(os.path.join(search_dir, 'config.json'), 'r') as f:
             config = JobConfig.from_json(json.load(f))
 
-        # Look for files
-        if os.path.isfile(os.path.join(search_dir, f"{config.name}.csv")):
-            file_dir = os.path.join(search_dir, f"{config.name}.csv")
-            if 'sparse_value' in config.model_params.keys() and os.path.isfile(os.path.join(search_dir, f"{config.name}_sparse.csv")):
-                file_dir = os.path.join(search_dir, f"{config.name}_sparse.csv")
+        # Look for files. Matrix-based models (specter2, scincl, specter2+scincl)
+        # produce {name}.pt + {name}_sparse.csv. Legacy tuple-based models (bm25,
+        # mfr, specter+mfr) still produce {name}.csv + {name}_sparse.csv.
+        # The API returns the sparse CSV in either case.
+        matrix_path = os.path.join(search_dir, f"{config.name}.pt")
+        full_csv_path = os.path.join(search_dir, f"{config.name}.csv")
+        sparse_csv_path = os.path.join(search_dir, f"{config.name}_sparse.csv")
+        if os.path.isfile(matrix_path) or os.path.isfile(full_csv_path):
+            if 'sparse_value' in config.model_params.keys() and os.path.isfile(sparse_csv_path):
+                file_dir = sparse_csv_path
+            elif os.path.isfile(full_csv_path):
+                # Legacy fallback: full CSV is acceptable if no sparse was requested.
+                file_dir = full_csv_path
             else:
                 raise OpenReviewException("Sparse score file not found for job {job_id}".format(job_id=config.job_id))
         else:

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -385,32 +385,20 @@ class BaseExpertiseService:
         :returns file_dir: The directory of the score file, if it exists, starting from the given directory
         :returns metadata_dir: The directory of the metadata file, if it exists, starting from the given directory
         """
-        # Search for scores files (if sparse scores exist, retrieve by default)
+        # Get results always returns sparse scores. The dispatch in
+        # execute_expertise unconditionally produces {name}_sparse.csv (
+        # sparse_value is a required positive integer, validated at config
+        # creation), so if the file isn't on disk something went wrong with
+        # the job and we surface that as an error rather than silently
+        # serving the wrong artifact.
         file_dir, metadata_dir = None, None
         with open(os.path.join(search_dir, 'config.json'), 'r') as f:
             config = JobConfig.from_json(json.load(f))
 
-        # Look for files. Matrix-based models (specter2, scincl, specter2+scincl)
-        # produce {name}.pt + {name}_sparse.csv. Legacy tuple-based models (bm25,
-        # mfr, specter+mfr) still produce {name}.csv + {name}_sparse.csv.
-        # The API returns the sparse CSV in either case.
-        matrix_path = os.path.join(search_dir, f"{config.name}.pt")
-        full_csv_path = os.path.join(search_dir, f"{config.name}.csv")
         sparse_csv_path = os.path.join(search_dir, f"{config.name}_sparse.csv")
-        # sparse_value is a required positive integer (validated at config
-        # creation), so a sparse CSV should always exist when the job
-        # completed successfully.
-        if os.path.isfile(matrix_path) or os.path.isfile(full_csv_path):
-            if os.path.isfile(sparse_csv_path):
-                file_dir = sparse_csv_path
-            elif os.path.isfile(full_csv_path):
-                # Legacy fallback: full CSV is acceptable if no sparse exists
-                # (older jobs that pre-date the sparse-required contract).
-                file_dir = full_csv_path
-            else:
-                raise OpenReviewException("Sparse score file not found for job {job_id}".format(job_id=config.job_id))
-        else:
-            raise OpenReviewException("Score file not found for job {job_id}".format(job_id=config.job_id))
+        if not os.path.isfile(sparse_csv_path):
+            raise OpenReviewException("Sparse score file not found for job {job_id}".format(job_id=config.job_id))
+        file_dir = sparse_csv_path
 
         if os.path.isfile(os.path.join(search_dir, 'metadata.json')):
             metadata_dir = os.path.join(search_dir, 'metadata.json')

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -397,11 +397,15 @@ class BaseExpertiseService:
         matrix_path = os.path.join(search_dir, f"{config.name}.pt")
         full_csv_path = os.path.join(search_dir, f"{config.name}.csv")
         sparse_csv_path = os.path.join(search_dir, f"{config.name}_sparse.csv")
+        # sparse_value is a required positive integer (validated at config
+        # creation), so a sparse CSV should always exist when the job
+        # completed successfully.
         if os.path.isfile(matrix_path) or os.path.isfile(full_csv_path):
-            if 'sparse_value' in config.model_params.keys() and os.path.isfile(sparse_csv_path):
+            if os.path.isfile(sparse_csv_path):
                 file_dir = sparse_csv_path
             elif os.path.isfile(full_csv_path):
-                # Legacy fallback: full CSV is acceptable if no sparse was requested.
+                # Legacy fallback: full CSV is acceptable if no sparse exists
+                # (older jobs that pre-date the sparse-required contract).
                 file_dir = full_csv_path
             else:
                 raise OpenReviewException("Sparse score file not found for job {job_id}".format(job_id=config.job_id))

--- a/expertise/service/routes.py
+++ b/expertise/service/routes.py
@@ -317,6 +317,7 @@ def results():
                         yield buf.getvalue()
                 except Exception as e:
                     flask.current_app.logger.error(f"Error in CSV streaming: {str(e)}", exc_info=True)
+                    raise
 
             return flask.Response(generate_csv(), mimetype='text/csv')
 

--- a/expertise/service/routes.py
+++ b/expertise/service/routes.py
@@ -5,6 +5,8 @@ from expertise.service.expertise import ExpertiseService, ExpertiseCloudService
 from expertise.service import model_ready, artifact_loading_started
 from expertise.service.utils import GCPInterface
 import openreview
+import csv
+import io
 import json
 from .utils import get_user_id
 import flask
@@ -275,50 +277,77 @@ def results():
         if job_id is None or len(job_id) == 0:
             raise openreview.OpenReviewException('Bad request: jobId is required')
         delete_on_get = flask.request.args.get('deleteOnGet', 'False').lower() == 'true'
+        # Optional response format: 'json' (default, backwards-compatible) or 'csv'.
+        # CSV is rows-only with an entityA,entityB,score header — useful for
+        # very large jobs where clients want to skip JSON parsing overhead.
+        response_format = flask.request.args.get('format', 'json').lower()
 
         expertise_service = get_expertise_service(flask.current_app.config, flask.current_app.logger)
         result = expertise_service.get_expertise_results(user_id, job_id, delete_on_get)
-        
-        # Check if result is a generator (for streaming) or a regular dict
+
+        # Normalize both service shapes (cloud=generator-of-chunks, local=dict)
+        # into a single iterable of result_item dicts. The CSV and JSON
+        # streaming generators below consume this uniformly.
+        def iter_result_items(res):
+            if hasattr(res, '__iter__') and not isinstance(res, (dict, list)):
+                for chunk in res:
+                    for item in chunk.get('results') or []:
+                        yield item
+            else:
+                for item in res.get('results') or []:
+                    yield item
+
+        if response_format == 'csv':
+            flask.current_app.logger.debug('Streaming CSV response')
+
+            def generate_csv():
+                try:
+                    buf = io.StringIO()
+                    writer = csv.writer(buf)
+                    writer.writerow(['entityA', 'entityB', 'score'])
+                    for item in iter_result_items(result):
+                        writer.writerow([item['entityA'], item['entityB'], item['score']])
+                        # Flush in ~8KB chunks to keep buffer small while still
+                        # amortizing yield overhead across many rows.
+                        if buf.tell() > 8192:
+                            yield buf.getvalue()
+                            buf.seek(0)
+                            buf.truncate()
+                    if buf.tell() > 0:
+                        yield buf.getvalue()
+                except Exception as e:
+                    flask.current_app.logger.error(f"Error in CSV streaming: {str(e)}", exc_info=True)
+
+            return flask.Response(generate_csv(), mimetype='text/csv')
+
+        # Default: JSON. Streaming for generator (cloud), single-shot jsonify for dict (local).
         if hasattr(result, '__iter__') and not isinstance(result, (dict, list)):
-            # It's a generator - use streaming response
             flask.current_app.logger.debug('Using streaming response')
-            
+
             def generate():
                 try:
-                    # Start with an opening bracket for a JSON array
                     yield '{"results":['
-                    
                     first_chunk = True
                     metadata = None
-                    
                     for chunk in result:
-                        # Save metadata for later
                         if chunk.get('metadata') is not None:
                             metadata = chunk['metadata']
-                        
-                        # Stream results
                         if chunk.get('results'):
                             for result_item in chunk['results']:
                                 if not first_chunk:
                                     yield ','
                                 yield json.dumps(result_item)
                                 first_chunk = False
-                    
-                    # Close the results array and add metadata
                     yield '],'
                     yield f'"metadata":{json.dumps(metadata or {})}'
                     yield '}'
-                    
                 except Exception as e:
                     flask.current_app.logger.error(f"Error in streaming: {str(e)}", exc_info=True)
-                    # If an error occurs during streaming, we need to yield a valid JSON
                     yield '[],"error":"Error during streaming"}'
 
             flask.current_app.logger.debug('Streaming response started')
             return flask.Response(generate(), mimetype='application/json')
         else:
-            # It's a regular dictionary - use standard JSON response
             flask.current_app.logger.debug('Using standard JSON response')
             return flask.jsonify(result), 200
 

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -729,7 +729,7 @@ class JobConfig(object):
         config.model_params['skip_specter'] = model_params.get('skip_specter', None)
         config.model_params['specter_batch_size'] = model_params.get('specter_batch_size', 16)
         config.model_params['mfr_batch_size'] = model_params.get('mfr_batch_size', 50)
-        config.model_params['sparse_value'] = model_params.get('sparse_value', 300)
+        config.model_params['sparse_value'] = model_params.get('sparse_value', 400)
         config.model_params['use_cuda'] = model_params.get('use_cuda', False)
         config.model_params['use_redis'] = model_params.get('use_redis', False)
         config.model_params['percentile_select'] = model_params.get('percentile_select', None)
@@ -760,7 +760,16 @@ class JobConfig(object):
 
                 snake_param = _camel_to_snake(param)
                 config.model_params[snake_param] = api_model[param]
-        
+
+        # sparse_value is a required field with a default; validate it's a
+        # positive integer so downstream code can rely on > 0 without
+        # defensive checks.
+        sparse_value = config.model_params.get('sparse_value')
+        if not isinstance(sparse_value, int) or sparse_value <= 0:
+            raise openreview.OpenReviewException(
+                f"Bad request: 'sparseValue' must be a positive integer, got {sparse_value!r}"
+            )
+
         # Set server-side path fields
         for field in path_fields:
             config.model_params[field] = root_dir

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -6,6 +6,7 @@ import tarfile
 import tempfile
 import time
 import json
+import csv
 import re
 import datetime
 import redis, pickle
@@ -1452,7 +1453,7 @@ class GCPInterface(object):
 
     def get_job_results(self, user_id, job_id, delete_on_get=False):
 
-        def _get_scores_and_metadata_streaming(all_blobs, job_id):
+        def _get_scores_and_metadata_streaming(all_blobs, job_id, group_group_matching, paper_paper_matching):
             """
             Extracts the scores and metadata from the GCS bucket and returns a generator that yields
             chunks of results to enable streaming
@@ -1468,7 +1469,9 @@ class GCPInterface(object):
                 blob for blob in all_blobs if 'metadata.json' in blob.name and 'dataset/' not in blob.name
             ]
             score_files = [
-                blob for blob in all_blobs if blob.name.endswith('scores.jsonl') or blob.name.endswith('scores_sparse.jsonl')
+                blob for blob in all_blobs
+                if blob.name.endswith('scores.csv') or blob.name.endswith('scores_sparse.csv')
+                or blob.name.endswith('scores.jsonl') or blob.name.endswith('scores_sparse.jsonl')
             ]
 
             if len(metadata_files) != 1:
@@ -1480,27 +1483,49 @@ class GCPInterface(object):
             metadata = json.loads(metadata_files[0].download_as_string())
             yield {'metadata': metadata, 'results': []}
 
-            # Helper function to stream scores from a blob file
+            # Helper function to stream scores from a blob file.
+            #
+            # - New CSV format: rows are in the model's natural order:
+            #   [test_id, reviewer_id, score] for mixed matching, or
+            #   [test_id, train_id, score] for symmetric matching. The
+            #   entityA/entityB swap mirrors the local service:
+            #     symmetric  -> {entityA: row[0], entityB: row[1]}
+            #     mixed      -> {entityB: row[0], entityA: row[1]}
+            #
+            # - Legacy JSONL format (in-flight jobs from before the CSV
+            #   migration): the entityA/entityB swap was already done at
+            #   upload time, so each line is consumed as-is.
             def stream_score_file(blob):
+                is_csv = blob.name.endswith('.csv')
                 downloader = blob.open('r')
-                chunk = downloader.readline()
                 results_chunk = []
-                chunk_size = 1000  # Adjust this number based on your data size
+                chunk_size = 1000
 
-                while chunk:
-                    if isinstance(chunk, bytes):
-                        chunk = chunk.decode('utf-8')
-                    if chunk.strip():
-                        results_chunk.append(json.loads(chunk.strip()))
-
-                    # Yield chunks of results
-                    if len(results_chunk) >= chunk_size:
-                        yield {'results': results_chunk, 'metadata': None}
-                        results_chunk = []
-
+                if is_csv:
+                    reader = csv.reader(downloader)
+                    for row in reader:
+                        if not row:
+                            continue
+                        if group_group_matching or paper_paper_matching:
+                            obj = {'entityA': row[0], 'entityB': row[1], 'score': float(row[2])}
+                        else:
+                            obj = {'entityB': row[0], 'entityA': row[1], 'score': float(row[2])}
+                        results_chunk.append(obj)
+                        if len(results_chunk) >= chunk_size:
+                            yield {'results': results_chunk, 'metadata': None}
+                            results_chunk = []
+                else:
                     chunk = downloader.readline()
+                    while chunk:
+                        if isinstance(chunk, bytes):
+                            chunk = chunk.decode('utf-8')
+                        if chunk.strip():
+                            results_chunk.append(json.loads(chunk.strip()))
+                        if len(results_chunk) >= chunk_size:
+                            yield {'results': results_chunk, 'metadata': None}
+                            results_chunk = []
+                        chunk = downloader.readline()
 
-                # Yield any remaining results
                 if results_chunk:
                     yield {'results': results_chunk, 'metadata': None}
 
@@ -1543,12 +1568,24 @@ class GCPInterface(object):
         # Validate score and metadata files exist before returning the streaming generator.
         # If validation is deferred into the generator, exceptions fire after the HTTP
         # response has already started — causing a broken chunked response on the client.
-        score_files = [blob for blob in job_blobs if blob.name.endswith('scores.jsonl') or blob.name.endswith('scores_sparse.jsonl')]
+        score_files = [
+            blob for blob in job_blobs
+            if blob.name.endswith('scores.csv') or blob.name.endswith('scores_sparse.csv')
+            or blob.name.endswith('scores.jsonl') or blob.name.endswith('scores_sparse.jsonl')
+        ]
         metadata_files = [blob for blob in job_blobs if 'metadata.json' in blob.name and 'dataset/' not in blob.name]
         if len(metadata_files) != 1:
             raise openreview.OpenReviewException(f'Internal Error: incorrect metadata files found expected [1] found {len(metadata_files)}')
         if len(score_files) < 1 or len(score_files) > 2:
             raise openreview.OpenReviewException(f'Internal Error: incorrect score files found expected [1, 2] found {len(score_files)}')
 
-        return _get_scores_and_metadata_streaming(job_blobs, job_id)
+        # Matching type drives the entityA/entityB column mapping for new CSV
+        # blobs (legacy JSONL blobs already have it baked in).
+        api_request = authenticated_requests[0]
+        entityA_type = api_request.get('entityA', {}).get('type', '')
+        entityB_type = api_request.get('entityB', {}).get('type', '')
+        group_group_matching = entityA_type == 'Group' and entityB_type == 'Group'
+        paper_paper_matching = entityA_type == 'Note' and entityB_type == 'Note'
+
+        return _get_scores_and_metadata_streaming(job_blobs, job_id, group_group_matching, paper_paper_matching)
 

--- a/expertise/utils/utils.py
+++ b/expertise/utils/utils.py
@@ -595,12 +595,14 @@ def aggregate_by_group(config):
             valid_idxs = [test_id_to_idx[pid] for pid in paper_ids if pid in test_id_to_idx]
             if not valid_idxs:
                 continue
-            # Mean across the profile's paper rows -> vector of size num_reviewers
+            # Mean across the profile's paper rows -> vector of size num_reviewers.
+            # Emit every (profile, reviewer) cell regardless of score value —
+            # the legacy CSV-based path stores the round result even when it
+            # rounds to 0.0, and we preserve that behavior.
             avg_row = scores_matrix[valid_idxs].mean(dim=0).tolist()
             average_score[profile_id] = {
                 reviewer_ids[j]: round(avg_row[j], 2)
                 for j in range(len(reviewer_ids))
-                if avg_row[j]
             }
     else:
         # Legacy tuple-based predictor that wrote {name}.csv directly.

--- a/expertise/utils/utils.py
+++ b/expertise/utils/utils.py
@@ -628,16 +628,14 @@ def aggregate_by_group(config):
                 if score_length:
                     average_score[profile_id][archive_id] = round(score_sum/score_length, 2)
 
+    # Build the in-memory list only — no CSV side-file. The aggregated CSV
+    # was previously written to {name}.csv and uploaded to GCS, but no
+    # downstream consumer reads it (the API always serves scores_sparse.csv,
+    # and execute_expertise consumes preliminary_scores in memory).
     preliminary_scores = []
-    # Write the aggregated scores to {name}.csv. For matrix-based models this
-    # creates the file (it didn't exist before — only {name}.pt did); for the
-    # legacy path it overwrites the prior contents.
-    with open(csv_path, 'w') as outfile:
-        csvwriter = csv.writer(outfile, delimiter=',')
-        for submission_member, archive_scores in average_score.items():
-            for archive_member, score in archive_scores.items():
-                preliminary_scores.append((archive_member, submission_member, score))
-                csvwriter.writerow([archive_member, submission_member, score])
+    for submission_member, archive_scores in average_score.items():
+        for archive_member, score in archive_scores.items():
+            preliminary_scores.append((archive_member, submission_member, score))
 
     return preliminary_scores
 

--- a/expertise/utils/utils.py
+++ b/expertise/utils/utils.py
@@ -539,22 +539,29 @@ def generate_sparse_scores_from_matrix(scores_matrix, test_id_list, reviewer_ids
 
     all_pairs = torch.unique(torch.cat([pairs_a, pairs_b], dim=0), dim=0)
 
-    # Bulk score lookup + tolist for fast Python iteration during CSV write.
-    sel_scores = scores_matrix[all_pairs[:, 0], all_pairs[:, 1]].tolist()
-    pairs_list = all_pairs.tolist()
-    print(f'  built {len(pairs_list)} sparse pairs in {time.perf_counter() - _t_total:.1f}s', flush=True)
+    # Bulk score lookup; kept as a tensor (calling .tolist() on ~16M floats
+    # at production scale would materialize >1GB of boxed Python objects).
+    sel_scores = scores_matrix[all_pairs[:, 0], all_pairs[:, 1]].cpu()
+    all_pairs = all_pairs.cpu()
+    n_pairs = int(all_pairs.shape[0])
+    print(f'  built {n_pairs} sparse pairs in {time.perf_counter() - _t_total:.1f}s', flush=True)
 
-    # Stream CSV write — no intermediate Python list, no sort. Output order
-    # is whatever torch.unique gives back (sorted lexicographically by
-    # (test_idx, rev_idx) ascending, so deterministic across runs). The
-    # /expertise/results consumers don't depend on a specific row order, so
-    # we don't pay the memory/CPU cost of an O(N log N) Python sort over
-    # ~16M tuples at production scale.
+    # Stream CSV write in chunks. Output order is whatever torch.unique gives
+    # back (lexicographic on (test_idx, rev_idx) ascending, deterministic
+    # across runs); /expertise/results consumers don't depend on a specific
+    # row order, so we don't pay an O(N log N) Python sort. Converting one
+    # chunk at a time bounds peak Python-object memory even when N is in
+    # the tens of millions (e.g. ~16M pairs for 35k×5k at k=400).
     if scores_path:
         _t0 = time.perf_counter()
+        chunk_size = 1_000_000
         with open(scores_path, 'w') as f:
-            for (i, j), score in zip(pairs_list, sel_scores):
-                f.write(f'{test_id_list[i]},{reviewer_ids[j]},{round(score, 4)}\n')
+            for start in range(0, n_pairs, chunk_size):
+                end = min(start + chunk_size, n_pairs)
+                chunk_pairs = all_pairs[start:end].tolist()
+                chunk_scores = sel_scores[start:end].tolist()
+                for (i, j), score in zip(chunk_pairs, chunk_scores):
+                    f.write(f'{test_id_list[i]},{reviewer_ids[j]},{round(score, 4)}\n')
         print(f'  wrote sparse CSV in {time.perf_counter() - _t0:.1f}s', flush=True)
 
     print(f'generate_sparse_scores_from_matrix total {time.perf_counter() - _t_total:.1f}s', flush=True)

--- a/expertise/utils/utils.py
+++ b/expertise/utils/utils.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, absolute_import, unicode_literals
 import codecs
 import sys
+import time
 import itertools
 import string
 import nltk
@@ -504,6 +505,53 @@ def generate_sparse_scores(full_scores, sparse_value, scores_path=None):
                 f.write('{0},{1},{2}\n'.format(note_id, profile_id, score))
 
     return sparse_scores
+
+def generate_sparse_scores_from_matrix(scores_matrix, test_id_list, reviewer_ids, sparse_value, scores_path):
+    """Compute the sparse score CSV directly from a [num_test, num_reviewers]
+    matrix via torch.topk on both axes, union+dedupe the (row, col) pairs,
+    and emit the result as CSV. Avoids materializing a list of all
+    num_test*num_reviewers (test_id, reviewer_id, score) tuples (which on
+    a large job is 175M tuples / ~17GB) and the two Python sorts that the
+    tuple-based generate_sparse_scores performs.
+    """
+    print(f'generate_sparse_scores_from_matrix: shape={tuple(scores_matrix.shape)} sparse_value={sparse_value}', flush=True)
+    _t_total = time.perf_counter()
+
+    n_test, n_rev = scores_matrix.shape
+    k_cols = min(sparse_value, n_rev) if sparse_value else 0
+    k_rows = min(sparse_value, n_test) if sparse_value else 0
+    if k_cols <= 0 or k_rows <= 0:
+        if scores_path:
+            open(scores_path, 'w').close()
+        return
+
+    # Top-K reviewers per submission (along columns).
+    _, top_rev_per_test = torch.topk(scores_matrix, k=k_cols, dim=1)    # [n_test, k_cols]
+    # Top-K submissions per reviewer (along rows).
+    _, top_test_per_rev = torch.topk(scores_matrix, k=k_rows, dim=0)    # [k_rows, n_rev]
+
+    # Build (test_idx, rev_idx) pairs from both views, vectorized.
+    test_ar = torch.arange(n_test).unsqueeze(1).expand(-1, k_cols).flatten()
+    pairs_a = torch.stack([test_ar, top_rev_per_test.flatten()], dim=1)
+
+    rev_ar = torch.arange(n_rev).unsqueeze(0).expand(k_rows, -1).flatten()
+    pairs_b = torch.stack([top_test_per_rev.flatten(), rev_ar], dim=1)
+
+    all_pairs = torch.unique(torch.cat([pairs_a, pairs_b], dim=0), dim=0)
+
+    # Bulk score lookup + tolist for fast Python iteration during CSV write.
+    sel_scores = scores_matrix[all_pairs[:, 0], all_pairs[:, 1]].tolist()
+    pairs_list = all_pairs.tolist()
+    print(f'  built {len(pairs_list)} sparse pairs in {time.perf_counter() - _t_total:.1f}s', flush=True)
+
+    if scores_path:
+        _t0 = time.perf_counter()
+        with open(scores_path, 'w') as f:
+            for (i, j), score in zip(pairs_list, sel_scores):
+                f.write(f'{test_id_list[i]},{reviewer_ids[j]},{round(score, 4)}\n')
+        print(f'  wrote sparse CSV in {time.perf_counter() - _t0:.1f}s', flush=True)
+
+    print(f'generate_sparse_scores_from_matrix total {time.perf_counter() - _t_total:.1f}s', flush=True)
 
 def aggregate_by_group(config):
     # Fetch scores

--- a/expertise/utils/utils.py
+++ b/expertise/utils/utils.py
@@ -544,11 +544,20 @@ def generate_sparse_scores_from_matrix(scores_matrix, test_id_list, reviewer_ids
     pairs_list = all_pairs.tolist()
     print(f'  built {len(pairs_list)} sparse pairs in {time.perf_counter() - _t_total:.1f}s', flush=True)
 
+    # Sort rows by (test_id desc, score desc) to match the legacy
+    # generate_sparse_scores final sort: sorted(..., key=lambda x: (x[0], x[2]),
+    # reverse=True). Consumers (clients, downstream pipelines) may depend on
+    # this ordering — keep it identical.
     if scores_path:
         _t0 = time.perf_counter()
+        rows = [
+            (test_id_list[i], reviewer_ids[j], round(score, 4))
+            for (i, j), score in zip(pairs_list, sel_scores)
+        ]
+        rows.sort(key=lambda r: (r[0], r[2]), reverse=True)
         with open(scores_path, 'w') as f:
-            for (i, j), score in zip(pairs_list, sel_scores):
-                f.write(f'{test_id_list[i]},{reviewer_ids[j]},{round(score, 4)}\n')
+            for test_id, reviewer_id, score in rows:
+                f.write(f'{test_id},{reviewer_id},{score}\n')
         print(f'  wrote sparse CSV in {time.perf_counter() - _t0:.1f}s', flush=True)
 
     print(f'generate_sparse_scores_from_matrix total {time.perf_counter() - _t_total:.1f}s', flush=True)

--- a/expertise/utils/utils.py
+++ b/expertise/utils/utils.py
@@ -563,51 +563,77 @@ def generate_sparse_scores_from_matrix(scores_matrix, test_id_list, reviewer_ids
     print(f'generate_sparse_scores_from_matrix total {time.perf_counter() - _t_total:.1f}s', flush=True)
 
 def aggregate_by_group(config):
-    # Fetch scores
-    scores = {}
-    original_score_path = Path(config['model_params']['scores_path']).joinpath(config['name'] + '.csv')
-    with open(original_score_path, 'r') as f:
-        csv_reader = csv.reader(f)
-        for line in csv_reader:
-            paper_id = line[0]
-            ac_id = line[1]
-            score = line[2]
-            if paper_id not in scores:
-                scores[paper_id] = {}
-            scores[paper_id][ac_id] = score
+    matrix_path = Path(config['model_params']['scores_path']).joinpath(config['name'] + '.pt')
+    csv_path = Path(config['model_params']['scores_path']).joinpath(config['name'] + '.csv')
 
     dataset_root = Path(config.get('dataset', {}).get('directory', './'))
 
-    # Fetch archive members
+    # Fetch archive members (group_A side — listed in archives/<id>.jsonl)
     archive_members = []
     archive_files = os.listdir(dataset_root.joinpath('archives'))
     for author_file in archive_files:
         archive_members.append(author_file[:-6])
 
-    # Fetch submission members
+    # Fetch submission members (group_B side) and their papers
     with open(dataset_root.joinpath('publications_by_profile_id.json'), 'r') as f:
         publications_by_profile_id = json.load(f)
     submission_members = publications_by_profile_id.keys()
 
-    # Perform averaging
     average_score = {}
-    for profile_id in submission_members:
-        paper_ids = [p['id'] for p in publications_by_profile_id[profile_id]]
-        for archive_id in archive_members:
-            score_sum = 0
-            score_length = 0
-            for paper_id in paper_ids:
-                if archive_id in scores.get(paper_id, {}):
-                    score_sum += float(scores[paper_id][archive_id])
-                    score_length += 1
-            if profile_id not in average_score:
-                average_score[profile_id] = {}
-            if score_length:
-                average_score[profile_id][archive_id] = round(score_sum/score_length, 2)
-    
+    if matrix_path.is_file():
+        # Matrix-based predictor: aggregate directly on the tensor. Avoids
+        # materializing a full [num_test x num_reviewers] nested dict, which
+        # at production scale was ~17 GB of Python objects.
+        data = torch.load(matrix_path)
+        scores_matrix = data['scores']        # [num_test, num_reviewers]
+        test_ids = data['test_ids']           # row labels (paper ids on the group_B side)
+        reviewer_ids = data['reviewer_ids']   # column labels (archive ids on the group_A side)
+        test_id_to_idx = {tid: i for i, tid in enumerate(test_ids)}
+
+        for profile_id in submission_members:
+            paper_ids = [p['id'] for p in publications_by_profile_id[profile_id]]
+            valid_idxs = [test_id_to_idx[pid] for pid in paper_ids if pid in test_id_to_idx]
+            if not valid_idxs:
+                continue
+            # Mean across the profile's paper rows -> vector of size num_reviewers
+            avg_row = scores_matrix[valid_idxs].mean(dim=0).tolist()
+            average_score[profile_id] = {
+                reviewer_ids[j]: round(avg_row[j], 2)
+                for j in range(len(reviewer_ids))
+                if avg_row[j]
+            }
+    else:
+        # Legacy tuple-based predictor that wrote {name}.csv directly.
+        scores = {}
+        with open(csv_path, 'r') as f:
+            csv_reader = csv.reader(f)
+            for line in csv_reader:
+                paper_id = line[0]
+                ac_id = line[1]
+                score = line[2]
+                if paper_id not in scores:
+                    scores[paper_id] = {}
+                scores[paper_id][ac_id] = score
+
+        for profile_id in submission_members:
+            paper_ids = [p['id'] for p in publications_by_profile_id[profile_id]]
+            for archive_id in archive_members:
+                score_sum = 0
+                score_length = 0
+                for paper_id in paper_ids:
+                    if archive_id in scores.get(paper_id, {}):
+                        score_sum += float(scores[paper_id][archive_id])
+                        score_length += 1
+                if profile_id not in average_score:
+                    average_score[profile_id] = {}
+                if score_length:
+                    average_score[profile_id][archive_id] = round(score_sum/score_length, 2)
+
     preliminary_scores = []
-    # Overwrite out new scores
-    with open(original_score_path, 'w') as outfile:
+    # Write the aggregated scores to {name}.csv. For matrix-based models this
+    # creates the file (it didn't exist before — only {name}.pt did); for the
+    # legacy path it overwrites the prior contents.
+    with open(csv_path, 'w') as outfile:
         csvwriter = csv.writer(outfile, delimiter=',')
         for submission_member, archive_scores in average_score.items():
             for archive_member, score in archive_scores.items():

--- a/expertise/utils/utils.py
+++ b/expertise/utils/utils.py
@@ -544,20 +544,17 @@ def generate_sparse_scores_from_matrix(scores_matrix, test_id_list, reviewer_ids
     pairs_list = all_pairs.tolist()
     print(f'  built {len(pairs_list)} sparse pairs in {time.perf_counter() - _t_total:.1f}s', flush=True)
 
-    # Sort rows by (test_id desc, score desc) to match the legacy
-    # generate_sparse_scores final sort: sorted(..., key=lambda x: (x[0], x[2]),
-    # reverse=True). Consumers (clients, downstream pipelines) may depend on
-    # this ordering — keep it identical.
+    # Stream CSV write — no intermediate Python list, no sort. Output order
+    # is whatever torch.unique gives back (sorted lexicographically by
+    # (test_idx, rev_idx) ascending, so deterministic across runs). The
+    # /expertise/results consumers don't depend on a specific row order, so
+    # we don't pay the memory/CPU cost of an O(N log N) Python sort over
+    # ~16M tuples at production scale.
     if scores_path:
         _t0 = time.perf_counter()
-        rows = [
-            (test_id_list[i], reviewer_ids[j], round(score, 4))
-            for (i, j), score in zip(pairs_list, sel_scores)
-        ]
-        rows.sort(key=lambda r: (r[0], r[2]), reverse=True)
         with open(scores_path, 'w') as f:
-            for test_id, reviewer_id, score in rows:
-                f.write(f'{test_id},{reviewer_id},{score}\n')
+            for (i, j), score in zip(pairs_list, sel_scores):
+                f.write(f'{test_id_list[i]},{reviewer_ids[j]},{round(score, 4)}\n')
         print(f'  wrote sparse CSV in {time.perf_counter() - _t0:.1f}s', flush=True)
 
     print(f'generate_sparse_scores_from_matrix total {time.perf_counter() - _t_total:.1f}s', flush=True)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='openreview-expertise',
-    version='2.2.1',
+    version='2.2.2',
     description='OpenReview paper-reviewer affinity modeling',
     url='https://github.com/openreview/openreview-expertise',
     author='OpenReview',

--- a/tests/test_aggregate_by_group.py
+++ b/tests/test_aggregate_by_group.py
@@ -181,11 +181,10 @@ def test_aggregate_by_group_matrix_skips_authors_with_no_known_papers(tmp_path):
     assert actual == {('~Rev1', '~AuthorA1'): 0.90}
 
 
-def test_aggregate_by_group_matrix_drops_zero_average(tmp_path):
-    """The legacy code only stored per-archive averages when score_length > 0
-    AND skipped the entry when the average rounded to 0 isn't explicitly
-    filtered. The matrix path matches by skipping cells whose avg rounds to 0
-    (rounded-to-2-decimals). Verify a true-zero score is dropped.
+def test_aggregate_by_group_matrix_preserves_zero_scores(tmp_path):
+    """The legacy code emits per-(archive, profile) rows for every reviewer
+    that scored at least one of the profile's papers, regardless of the
+    rounded value. The matrix path matches this: zero scores aren't dropped.
     """
     publications_by_profile_id = {
         '~AuthorA1': [{'id': 'paperA1'}],
@@ -197,7 +196,7 @@ def test_aggregate_by_group_matrix_drops_zero_average(tmp_path):
         publications_by_profile_id=publications_by_profile_id,
     )
 
-    # Rev2 has score 0.001 which rounds to 0.00 at 2 decimals -> dropped.
+    # Rev2 score 0.001 rounds to 0.0 — kept; Rev1 score 0.9 -> 0.90.
     scores_matrix = torch.tensor([[0.9, 0.001]])
     torch.save(
         {'scores': scores_matrix, 'test_ids': ['paperA1'], 'reviewer_ids': ['~Rev1', '~Rev2']},
@@ -206,4 +205,59 @@ def test_aggregate_by_group_matrix_drops_zero_average(tmp_path):
 
     preliminary_scores = aggregate_by_group(config)
     actual = {(rev, sub): score for rev, sub, score in preliminary_scores}
-    assert actual == {('~Rev1', '~AuthorA1'): 0.90}
+    assert actual == {
+        ('~Rev1', '~AuthorA1'): 0.90,
+        ('~Rev2', '~AuthorA1'): 0.00,
+    }
+
+
+def test_aggregate_by_group_matrix_and_csv_paths_produce_same_output(tmp_path):
+    """Direct cross-check: run both code paths on equivalent input data and
+    assert they produce identical preliminary_scores. Catches any drift
+    between the legacy CSV-based aggregation and the new matrix-based one.
+    """
+    publications_by_profile_id = {
+        '~AuthorA1': [{'id': 'paperA1'}, {'id': 'paperA2'}],
+        '~AuthorB1': [{'id': 'paperB1'}],
+    }
+    archive_members = ['~Rev1', '~Rev2']
+
+    # Same matrix values, written to both .pt and .csv forms under separate dirs.
+    csv_rows = [
+        ('paperA1', '~Rev1', 0.8), ('paperA1', '~Rev2', 0.2),
+        ('paperA2', '~Rev1', 0.4), ('paperA2', '~Rev2', 0.6),
+        ('paperB1', '~Rev1', 0.5), ('paperB1', '~Rev2', 0.7),
+    ]
+    matrix = torch.tensor([
+        [0.8, 0.2],
+        [0.4, 0.6],
+        [0.5, 0.7],
+    ])
+
+    # Matrix path
+    _, matrix_scores_dir, matrix_config = _setup_job_dir(
+        tmp_path / 'matrix',
+        archive_members=archive_members,
+        publications_by_profile_id=publications_by_profile_id,
+    )
+    torch.save(
+        {'scores': matrix, 'test_ids': ['paperA1', 'paperA2', 'paperB1'], 'reviewer_ids': ['~Rev1', '~Rev2']},
+        matrix_scores_dir / 'test_run.pt',
+    )
+    matrix_result = aggregate_by_group(matrix_config)
+
+    # CSV path
+    _, csv_scores_dir, csv_config = _setup_job_dir(
+        tmp_path / 'csv',
+        archive_members=archive_members,
+        publications_by_profile_id=publications_by_profile_id,
+    )
+    with open(csv_scores_dir / 'test_run.csv', 'w') as f:
+        w = csv_mod.writer(f)
+        for r in csv_rows:
+            w.writerow(r)
+    csv_result = aggregate_by_group(csv_config)
+
+    matrix_dict = {(rev, sub): score for rev, sub, score in matrix_result}
+    csv_dict = {(rev, sub): score for rev, sub, score in csv_result}
+    assert matrix_dict == csv_dict

--- a/tests/test_aggregate_by_group.py
+++ b/tests/test_aggregate_by_group.py
@@ -1,0 +1,209 @@
+"""Unit tests for aggregate_by_group covering the matrix-based path.
+
+aggregate_by_group is the group-vs-group flow: scores are produced per
+(entityB_paper, entityA_member) by the model, then re-averaged into
+per-(entityB_member, entityA_member) by this function. After the matrix
+refactor, the model writes {name}.pt instead of {name}.csv, so
+aggregate_by_group must load the .pt file when present and aggregate in
+matrix space rather than reading the (now non-existent) CSV.
+
+This file pins down both code paths:
+- matrix path (.pt exists): aggregation happens via tensor ops.
+- legacy path (.csv exists, .pt does not): aggregation via the original
+  nested-dict iteration.
+
+Both paths must produce the same output for the same input.
+"""
+import csv as csv_mod
+import json
+import os
+from pathlib import Path
+
+import torch
+
+from expertise.utils.utils import aggregate_by_group
+
+
+def _setup_job_dir(tmp_path, *, archive_members, publications_by_profile_id):
+    """Build the directory layout aggregate_by_group expects:
+        <dataset_dir>/archives/<member>.jsonl  (entityA members)
+        <dataset_dir>/publications_by_profile_id.json  (entityB members -> papers)
+    Returns the dataset_dir, scores_dir, and config dict to pass in.
+    """
+    dataset_dir = tmp_path / 'dataset'
+    archives_dir = dataset_dir / 'archives'
+    archives_dir.mkdir(parents=True)
+    for member in archive_members:
+        (archives_dir / f'{member}.jsonl').write_text('')
+
+    with open(dataset_dir / 'publications_by_profile_id.json', 'w') as f:
+        json.dump(publications_by_profile_id, f)
+
+    scores_dir = tmp_path / 'scores'
+    scores_dir.mkdir()
+
+    config = {
+        'name': 'test_run',
+        'model_params': {'scores_path': str(scores_dir)},
+        'dataset': {'directory': str(dataset_dir)},
+    }
+    return dataset_dir, scores_dir, config
+
+
+def test_aggregate_by_group_matrix_path(tmp_path):
+    """When {name}.pt exists, aggregate_by_group loads it and averages each
+    entityB member's paper rows -> per-(entityB_member, entityA_member) score.
+    """
+    # entityB members and their papers
+    publications_by_profile_id = {
+        '~AuthorA1': [{'id': 'paperA1'}, {'id': 'paperA2'}],
+        '~AuthorB1': [{'id': 'paperB1'}],
+    }
+    # entityA members (reviewers, on the archives side)
+    archive_members = ['~Rev1', '~Rev2']
+
+    _, scores_dir, config = _setup_job_dir(
+        tmp_path,
+        archive_members=archive_members,
+        publications_by_profile_id=publications_by_profile_id,
+    )
+
+    # Matrix: rows = entityB papers (test_ids), cols = entityA members (reviewer_ids)
+    #          ~Rev1  ~Rev2
+    # paperA1   0.8    0.2
+    # paperA2   0.4    0.6
+    # paperB1   0.5    0.7
+    scores_matrix = torch.tensor([
+        [0.8, 0.2],
+        [0.4, 0.6],
+        [0.5, 0.7],
+    ])
+    test_ids = ['paperA1', 'paperA2', 'paperB1']
+    reviewer_ids = ['~Rev1', '~Rev2']
+    torch.save(
+        {'scores': scores_matrix, 'test_ids': test_ids, 'reviewer_ids': reviewer_ids},
+        scores_dir / 'test_run.pt',
+    )
+
+    preliminary_scores = aggregate_by_group(config)
+
+    # AuthorA papers: [paperA1, paperA2] -> rows 0, 1
+    #   Rev1 avg = (0.8 + 0.4) / 2 = 0.60
+    #   Rev2 avg = (0.2 + 0.6) / 2 = 0.40
+    # AuthorB papers: [paperB1] -> row 2
+    #   Rev1 = 0.50
+    #   Rev2 = 0.70
+    expected = {
+        ('~Rev1', '~AuthorA1'): 0.60,
+        ('~Rev2', '~AuthorA1'): 0.40,
+        ('~Rev1', '~AuthorB1'): 0.50,
+        ('~Rev2', '~AuthorB1'): 0.70,
+    }
+
+    actual = {(rev, sub): score for rev, sub, score in preliminary_scores}
+    assert actual == expected
+
+    # aggregate_by_group also writes the result as {name}.csv.
+    csv_path = scores_dir / 'test_run.csv'
+    assert csv_path.exists()
+    with open(csv_path) as f:
+        csv_rows = {(row[0], row[1]): float(row[2]) for row in csv_mod.reader(f) if row}
+    assert csv_rows == expected
+
+
+def test_aggregate_by_group_csv_path_unchanged(tmp_path):
+    """Legacy path: {name}.csv exists, {name}.pt doesn't. Original nested-dict
+    aggregation is used and produces equivalent output to the matrix path.
+    """
+    publications_by_profile_id = {
+        '~AuthorA1': [{'id': 'paperA1'}, {'id': 'paperA2'}],
+        '~AuthorB1': [{'id': 'paperB1'}],
+    }
+    archive_members = ['~Rev1', '~Rev2']
+
+    _, scores_dir, config = _setup_job_dir(
+        tmp_path,
+        archive_members=archive_members,
+        publications_by_profile_id=publications_by_profile_id,
+    )
+
+    # Write the legacy {name}.csv (paper_id, ac_id, score).
+    csv_rows = [
+        ('paperA1', '~Rev1', 0.8), ('paperA1', '~Rev2', 0.2),
+        ('paperA2', '~Rev1', 0.4), ('paperA2', '~Rev2', 0.6),
+        ('paperB1', '~Rev1', 0.5), ('paperB1', '~Rev2', 0.7),
+    ]
+    with open(scores_dir / 'test_run.csv', 'w') as f:
+        w = csv_mod.writer(f)
+        for r in csv_rows:
+            w.writerow(r)
+
+    preliminary_scores = aggregate_by_group(config)
+    actual = {(rev, sub): score for rev, sub, score in preliminary_scores}
+    expected = {
+        ('~Rev1', '~AuthorA1'): 0.60,
+        ('~Rev2', '~AuthorA1'): 0.40,
+        ('~Rev1', '~AuthorB1'): 0.50,
+        ('~Rev2', '~AuthorB1'): 0.70,
+    }
+    assert actual == expected
+
+
+def test_aggregate_by_group_matrix_skips_authors_with_no_known_papers(tmp_path):
+    """If an entityB member's paper_ids are all missing from the matrix's
+    test_ids (e.g. they weren't part of the scoring run), their entry should
+    be skipped — same as the legacy code which produced no per-archive entry
+    when score_length was 0.
+    """
+    publications_by_profile_id = {
+        '~AuthorA1': [{'id': 'paperA1'}],
+        '~AuthorMissing1': [{'id': 'ghost_paper'}],  # not in test_ids
+    }
+    archive_members = ['~Rev1']
+
+    _, scores_dir, config = _setup_job_dir(
+        tmp_path,
+        archive_members=archive_members,
+        publications_by_profile_id=publications_by_profile_id,
+    )
+
+    scores_matrix = torch.tensor([[0.9]])
+    test_ids = ['paperA1']
+    reviewer_ids = ['~Rev1']
+    torch.save(
+        {'scores': scores_matrix, 'test_ids': test_ids, 'reviewer_ids': reviewer_ids},
+        scores_dir / 'test_run.pt',
+    )
+
+    preliminary_scores = aggregate_by_group(config)
+    actual = {(rev, sub): score for rev, sub, score in preliminary_scores}
+    # AuthorMissing1 had no papers in test_ids -> skipped.
+    assert actual == {('~Rev1', '~AuthorA1'): 0.90}
+
+
+def test_aggregate_by_group_matrix_drops_zero_average(tmp_path):
+    """The legacy code only stored per-archive averages when score_length > 0
+    AND skipped the entry when the average rounded to 0 isn't explicitly
+    filtered. The matrix path matches by skipping cells whose avg rounds to 0
+    (rounded-to-2-decimals). Verify a true-zero score is dropped.
+    """
+    publications_by_profile_id = {
+        '~AuthorA1': [{'id': 'paperA1'}],
+    }
+    archive_members = ['~Rev1', '~Rev2']
+    _, scores_dir, config = _setup_job_dir(
+        tmp_path,
+        archive_members=archive_members,
+        publications_by_profile_id=publications_by_profile_id,
+    )
+
+    # Rev2 has score 0.001 which rounds to 0.00 at 2 decimals -> dropped.
+    scores_matrix = torch.tensor([[0.9, 0.001]])
+    torch.save(
+        {'scores': scores_matrix, 'test_ids': ['paperA1'], 'reviewer_ids': ['~Rev1', '~Rev2']},
+        scores_dir / 'test_run.pt',
+    )
+
+    preliminary_scores = aggregate_by_group(config)
+    actual = {(rev, sub): score for rev, sub, score in preliminary_scores}
+    assert actual == {('~Rev1', '~AuthorA1'): 0.90}

--- a/tests/test_aggregate_by_group.py
+++ b/tests/test_aggregate_by_group.py
@@ -103,12 +103,9 @@ def test_aggregate_by_group_matrix_path(tmp_path):
     actual = {(rev, sub): score for rev, sub, score in preliminary_scores}
     assert actual == expected
 
-    # aggregate_by_group also writes the result as {name}.csv.
+    # No side-file CSV is written — preliminary_scores is in-memory only.
     csv_path = scores_dir / 'test_run.csv'
-    assert csv_path.exists()
-    with open(csv_path) as f:
-        csv_rows = {(row[0], row[1]): float(row[2]) for row in csv_mod.reader(f) if row}
-    assert csv_rows == expected
+    assert not csv_path.exists()
 
 
 def test_aggregate_by_group_csv_path_unchanged(tmp_path):

--- a/tests/test_expertise_apiv2.py
+++ b/tests/test_expertise_apiv2.py
@@ -2,6 +2,8 @@ from expertise.create_dataset import OpenReviewExpertise
 from unittest.mock import patch, MagicMock
 from collections import defaultdict
 import openreview
+import csv
+import io
 import json
 import random
 from pathlib import Path
@@ -1003,11 +1005,49 @@ class TestExpertiseV2():
 
         response = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': f'{job_id}'})
         metadata = response.json['metadata']
-        response = response.json['results']
-        for item in response:
+        json_rows = response.json['results']
+        for item in json_rows:
             print(item)
             submission_id, profile_id, score = item['entityB'], item['entityA'], float(item['score'])
             assert len(submission_id) >= 1
             assert len(profile_id) >= 1
             assert profile_id.startswith('~')
             assert score >= 0 and score <= 1
+
+        # Now query the same job with format=csv and verify the values match
+        # the JSON response. This pins down the contract that format=csv is a
+        # representation switch only — same data, different envelope.
+        csv_response = test_client.get(
+            '/expertise/results',
+            headers=openreview_client.headers,
+            query_string={'jobId': f'{job_id}', 'format': 'csv'},
+        )
+        assert csv_response.status_code == 200
+        assert csv_response.mimetype == 'text/csv'
+
+        csv_text = csv_response.get_data(as_text=True)
+        csv_reader = csv.reader(io.StringIO(csv_text))
+        header = next(csv_reader)
+        assert header == ['entityA', 'entityB', 'score']
+        csv_rows = [
+            {'entityA': row[0], 'entityB': row[1], 'score': float(row[2])}
+            for row in csv_reader
+            if row
+        ]
+
+        # Same number of rows in both formats.
+        assert len(csv_rows) == len(json_rows)
+
+        # Build (entityA, entityB) -> score lookups so we can compare values
+        # by pair (order shouldn't matter for the contract).
+        csv_by_pair = {(r['entityA'], r['entityB']): r['score'] for r in csv_rows}
+        json_by_pair = {(r['entityA'], r['entityB']): r['score'] for r in json_rows}
+        assert csv_by_pair.keys() == json_by_pair.keys(), (
+            f"CSV and JSON disagree on which (entityA, entityB) pairs were emitted.\n"
+            f"  only-in-csv: {csv_by_pair.keys() - json_by_pair.keys()}\n"
+            f"  only-in-json: {json_by_pair.keys() - csv_by_pair.keys()}"
+        )
+        for pair, csv_score in csv_by_pair.items():
+            assert abs(csv_score - json_by_pair[pair]) < 1e-9, (
+                f"Score mismatch for {pair}: csv={csv_score} json={json_by_pair[pair]}"
+            )

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -1282,11 +1282,10 @@ class TestExpertiseService():
 
 
     def test_request_expertise_with_model_errors(self, openreview_client, openreview_context):
-        # Submit a config with an error in the model field and return the job_id
-        MAX_TIMEOUT = 600 # Timeout after 10 minutes
+        # sparseValue must be a positive integer; the config layer validates
+        # this on submit (POST) and rejects with HTTP 400 before any job is
+        # queued, so the worker never sees a malformed value at runtime.
         test_client = openreview_context['test_client']
-        queue_before = openreview_client.get_jobs_status()
-        failed_before = queue_before['expertiseQueueMQStatus']['failed']
         response = test_client.post(
             '/expertise',
             data = json.dumps({
@@ -1295,15 +1294,15 @@ class TestExpertiseService():
                         'type': "Group",
                         'memberOf': "ABC.cc/Reviewers",
                     },
-                    "entityB": { 
+                    "entityB": {
                         'type': "Note",
-                        'invitation': "ABC.cc/-/Submission" 
+                        'invitation': "ABC.cc/-/Submission"
                     },
                     "model": {
                             "name": "specter+mfr",
                             'sparseValue': 'notAnInt',
-                            'useTitle': None, 
-                            'useAbstract': None, 
+                            'useTitle': None,
+                            'useAbstract': None,
                             'skipSpecter': False,
                             'scoreComputation': 'avg'
                     }
@@ -1312,50 +1311,23 @@ class TestExpertiseService():
             content_type='application/json',
             headers=openreview_client.headers
         )
-        assert response.status_code == 200, f'{response.json}'
-        job_id = response.json['jobId']
+        assert response.status_code == 400, f'{response.json}'
+        assert 'sparseValue' in response.json['message']
 
-        start_time = time.time()
-        try_time = time.time() - start_time
-        failed_after = failed_before
-        while failed_after <= failed_before and try_time <= MAX_TIMEOUT:
-            time.sleep(5)
-            queue_after = openreview_client.get_jobs_status()
-            failed_after = queue_after['expertiseQueueMQStatus']['failed']
-            try_time = time.time() - start_time
-
-        assert try_time <= MAX_TIMEOUT, 'Expertise queue error count did not increase in time'
-        assert failed_after > failed_before
-        openreview_context['job_id'] = job_id
-
-    def test_get_results_and_get_error(self, openreview_client, openreview_context):
-        MAX_TIMEOUT = 600 # Timeout after 10 minutes
-        assert openreview_context['job_id'] is not None
+    def test_get_results_for_unknown_job(self, openreview_client, openreview_context):
+        """/expertise/results returns 404 for a job_id that doesn't exist.
+        Previously this was tested via a bad-sparseValue job that errored at
+        runtime — now sparseValue is validated at submit time (HTTP 400, no
+        job created), so we test the unknown-job-id path directly with a
+        synthetic id.
+        """
         test_client = openreview_context['test_client']
-        # Query until job is err
-        time.sleep(5)
-        response = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': f"{openreview_context['job_id']}"})
+        response = test_client.get(
+            '/expertise/results',
+            headers=openreview_client.headers,
+            query_string={'jobId': 'nonexistent_job_id'},
+        )
         assert response.status_code == 404
-
-        response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f"{openreview_context['job_id']}"}).json
-        start_time = time.time()
-        try_time = time.time() - start_time
-        while response['status'] != 'Error' and try_time <= MAX_TIMEOUT:
-            time.sleep(5)
-            response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f"{openreview_context['job_id']}"}).json
-            try_time = time.time() - start_time
-
-        assert try_time <= MAX_TIMEOUT, 'Job has not completed in time'
-        assert response['name'] == 'test_run'
-        assert response['status'].strip() == 'Error'
-        assert response['description'] == "'<' not supported between instances of 'int' and 'str'"
-        assert response['cdate'] <= response['mdate']
-        ###assert os.path.isfile(f"{server_config['WORKING_DIR']}/{job_id}/err.log")
-
-        # Clean up error job by calling the delete endpoint
-        response = test_client.delete(f'/expertise/{openreview_context["job_id"]}', headers=openreview_client.headers)
-        assert response.status_code == 200
-        assert not os.path.isdir(f"./tests/jobs/{openreview_context['job_id']}")
 
     def test_request_expertise_with_no_submission_error(self, openreview_client, openreview_context):
         # Submit a config with no submissions
@@ -1487,7 +1459,10 @@ class TestExpertiseService():
                 break
         assert target_id is not None
 
-        error_queue_before = openreview_client.get_jobs_status()
+        # Submit with a malformed sparseValue. Config validation rejects with
+        # HTTP 400 at the API boundary — no job is created, the worker never
+        # sees the bad input, and the expertise queue's failure counter
+        # therefore does not increment.
         response = test_client.post(
             '/expertise',
             data = json.dumps({
@@ -1497,16 +1472,16 @@ class TestExpertiseService():
                         'memberOf': "ABC.cc/Reviewers",
                         'expertise': {  'invitation': 'EXCLUSION.cc/Reviewers/-/Expertise_Selection'  }
                     },
-                    "entityB": { 
+                    "entityB": {
                         'type': "Note",
-                        'invitation': "ABC.cc/-/Submission" 
+                        'invitation': "ABC.cc/-/Submission"
                     },
                     "model": {
                             "name": "specter2+scincl",
                             'sparseValue': 'notAnInt',
                             'useTitle': None,
                             'useAbstract': None,
-                            'skipSpecter': False,   
+                            'skipSpecter': False,
                             'scoreComputation': 'avg'
                     }
                 }
@@ -1514,35 +1489,8 @@ class TestExpertiseService():
             content_type='application/json',
             headers=openreview_client.headers
         )
-        assert response.status_code == 200, f'{response.json}'
-        error_job_id = response.json['jobId']
-
-        time.sleep(5)
-        response = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': f"{error_job_id}"})
-        assert response.status_code == 404
-
-        response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f"{error_job_id}"}).json
-        start_time = time.time()
-        try_time = time.time() - start_time
-        while response['status'] != 'Error' and try_time <= MAX_TIMEOUT:
-            time.sleep(5)
-            response = test_client.get('/expertise/status', headers=openreview_client.headers, query_string={'jobId': f"{error_job_id}"}).json
-            try_time = time.time() - start_time
-
-        assert try_time <= MAX_TIMEOUT, 'Job has not completed in time'
-        assert response['name'] == 'test_run'
-        assert response['status'].strip() == 'Error'
-        assert response['description'] == "'<' not supported between instances of 'int' and 'str'"
-        assert response['cdate'] <= response['mdate']
-        error_queue_after = helpers.await_queue_error(
-            openreview_client,
-            queue_names=['expertiseQueueMQStatus']
-        )
-        assert error_queue_after['expertiseQueueMQStatus']['failed'] > error_queue_before['expertiseQueueMQStatus']['failed']
-
-        response = test_client.delete(f'/expertise/{error_job_id}', headers=openreview_client.headers)
-        assert response.status_code == 200
-        assert not os.path.isdir(f"./tests/jobs/{error_job_id}")
+        assert response.status_code == 400, f'{response.json}'
+        assert 'sparseValue' in response.json['message']
     
     def test_delete_job_without_authorization(self, openreview_client, openreview_context):
         """Test that DELETE endpoint returns 403 when no authorization headers are provided"""

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -820,7 +820,8 @@ class TestExpertiseService():
         assert response['status'] == 'Completed'
         assert response['name'] == 'test_run'
         assert response['description'] == 'Job is complete and the computed scores are ready'
-        assert os.path.getsize(f"./tests/jobs/{job_id}/test_run.csv") == os.path.getsize(f"./tests/jobs/{job_id}/test_run_sparse.csv")
+        assert os.path.isfile(f"./tests/jobs/{job_id}/test_run.pt")
+        assert os.path.isfile(f"./tests/jobs/{job_id}/test_run_sparse.csv")
 
         # Check for API request
         req = response['request']
@@ -2400,7 +2401,8 @@ class TestExpertiseService():
         assert response['status'] == 'Completed'
         assert response['name'] == 'test_run'
         assert response['description'] == 'Job is complete and the computed scores are ready'
-        assert os.path.getsize(f"./tests/jobs/{job_id}/test_run.csv") == os.path.getsize(f"./tests/jobs/{job_id}/test_run_sparse.csv")
+        assert os.path.isfile(f"./tests/jobs/{job_id}/test_run.pt")
+        assert os.path.isfile(f"./tests/jobs/{job_id}/test_run_sparse.csv")
 
         # Get normalized mean
         response = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': job_id})
@@ -2463,7 +2465,8 @@ class TestExpertiseService():
         assert response['status'] == 'Completed'
         assert response['name'] == 'test_run'
         assert response['description'] == 'Job is complete and the computed scores are ready'
-        assert os.path.getsize(f"./tests/jobs/{unnorm_job_id}/test_run.csv") == os.path.getsize(f"./tests/jobs/{unnorm_job_id}/test_run_sparse.csv")
+        assert os.path.isfile(f"./tests/jobs/{unnorm_job_id}/test_run.pt")
+        assert os.path.isfile(f"./tests/jobs/{unnorm_job_id}/test_run_sparse.csv")
 
         # Check that normalized scores are different
         response = test_client.get('/expertise/results', headers=openreview_client.headers, query_string={'jobId': unnorm_job_id})

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,5 +1,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
+import csv
+import io
 import json
 import os
 import shutil
@@ -131,13 +133,16 @@ def test_run_pipeline(mock_load_model_artifacts, mock_execute_expertise, openrev
     bucket = gcs_test_bucket
     prefix = f"{gcs_jobs_prefix}/test_prefix/"
 
-    # Check for scores.jsonl file
-    scores_blob = bucket.blob(f"{prefix}scores.jsonl")
+    # Pipeline uploads scores.csv directly (no upload-time JSONL conversion).
+    # The entityA/entityB column-swap for mixed Group/Note matching happens at
+    # read time in the cloud reader, not here. So the GCS CSV rows match the
+    # source CSV byte-for-byte: cols [test_id, reviewer_id, score].
+    scores_blob = bucket.blob(f"{prefix}scores.csv")
     assert scores_blob.exists()
     scores_content = scores_blob.download_as_text()
-    scores_data = [json.loads(line) for line in scores_content.strip().split('\n')]
-    assert {"entityA": "test_user", "entityB": "note1", "score": 0.5} in scores_data
-    assert {"entityA": "test_user", "entityB": "note2", "score": 0.5} in scores_data
+    scores_rows = list(csv.reader(io.StringIO(scores_content)))
+    assert ['note1', 'test_user', '0.5'] in scores_rows
+    assert ['note2', 'test_user', '0.5'] in scores_rows
 
     # Check for metadata.json file
     metadata_blob = bucket.blob(f"{prefix}metadata.json")
@@ -239,13 +244,16 @@ def test_run_pipeline_gcsdir(mock_load_model_artifacts, mock_execute_expertise, 
     bucket = gcs_test_bucket
     prefix = f"{gcs_jobs_prefix}/test_prefix_gcs_dir/"
 
-    # Check for scores.jsonl file
-    scores_blob = bucket.blob(f"{prefix}scores.jsonl")
+    # Pipeline uploads scores.csv directly (no upload-time JSONL conversion).
+    # The entityA/entityB column-swap for mixed Group/Note matching happens at
+    # read time in the cloud reader, not here. So the GCS CSV rows match the
+    # source CSV byte-for-byte: cols [test_id, reviewer_id, score].
+    scores_blob = bucket.blob(f"{prefix}scores.csv")
     assert scores_blob.exists()
     scores_content = scores_blob.download_as_text()
-    scores_data = [json.loads(line) for line in scores_content.strip().split('\n')]
-    assert {"entityA": "test_user", "entityB": "note1", "score": 0.5} in scores_data
-    assert {"entityA": "test_user", "entityB": "note2", "score": 0.5} in scores_data
+    scores_rows = list(csv.reader(io.StringIO(scores_content)))
+    assert ['note1', 'test_user', '0.5'] in scores_rows
+    assert ['note2', 'test_user', '0.5'] in scores_rows
 
     # Check for metadata.json file
     metadata_blob = bucket.blob(f"{prefix}metadata.json")
@@ -345,12 +353,13 @@ def test_run_pipeline_group(mock_load_model_artifacts, mock_execute_expertise, o
     # Ensure execute_create_dataset and execute_expertise were called
     mock_execute_expertise.assert_called_once()
 
-    # Check for scores.jsonl file
-    scores_blob = bucket.blob(f"{prefix}scores.jsonl")
+    # Pipeline uploads scores.csv directly (group-group matching: cols are
+    # already [entityA, entityB, score] in canonical order).
+    scores_blob = bucket.blob(f"{prefix}scores.csv")
     assert scores_blob.exists()
     scores_content = scores_blob.download_as_text()
-    scores_data = [json.loads(line) for line in scores_content.strip().split('\n')]
-    assert {"entityA": "test_user", "entityB": "sub_user", "score": 0.5} in scores_data
+    scores_rows = list(csv.reader(io.StringIO(scores_content)))
+    assert ['test_user', 'sub_user', '0.5'] in scores_rows
 
     # Check for metadata.json file
     metadata_blob = bucket.blob(f"{prefix}metadata.json")
@@ -448,12 +457,13 @@ def test_run_pipeline_paper_paper(mock_load_model_artifacts, mock_execute_expert
     # Ensure execute_create_dataset and execute_expertise were called
     mock_execute_expertise.assert_called_once()
 
-    # Check for scores.jsonl file
-    scores_blob = bucket.blob(f"{prefix}scores.jsonl")
+    # Pipeline uploads scores.csv directly (paper-paper matching: cols are
+    # already [entityA, entityB, score] in canonical order).
+    scores_blob = bucket.blob(f"{prefix}scores.csv")
     assert scores_blob.exists()
     scores_content = scores_blob.download_as_text()
-    scores_data = [json.loads(line) for line in scores_content.strip().split('\n')]
-    assert {"entityA": "sub_one", "entityB": "sub_two", "score": 0.5} in scores_data
+    scores_rows = list(csv.reader(io.StringIO(scores_content)))
+    assert ['sub_one', 'sub_two', '0.5'] in scores_rows
 
     # Check for metadata.json file
     metadata_blob = bucket.blob(f"{prefix}metadata.json")

--- a/tests/test_sparse_scores_from_matrix.py
+++ b/tests/test_sparse_scores_from_matrix.py
@@ -180,3 +180,24 @@ def test_zero_sparse_value_produces_empty_file(tmp_path):
     generate_sparse_scores_from_matrix(matrix, ['t0'], ['r0', 'r1'], sparse_value=0, scores_path=out_path)
     assert out_path.exists()
     assert out_path.read_text() == ''
+
+
+def test_empty_reviewer_axis_produces_empty_file(tmp_path):
+    """When the model produces a [num_test, 0] matrix because no reviewers
+    were eligible (every train_note_id_list empty or all publications were
+    in the bad_id_set), the sparse generator must emit an empty file rather
+    than crash on torch.topk(k=0, dim=1)."""
+    matrix = torch.empty((3, 0))
+    out_path = tmp_path / 'sparse.csv'
+    generate_sparse_scores_from_matrix(matrix, ['t0', 't1', 't2'], [], sparse_value=10, scores_path=out_path)
+    assert out_path.exists()
+    assert out_path.read_text() == ''
+
+
+def test_empty_test_axis_produces_empty_file(tmp_path):
+    """Symmetric: 0 test rows, some reviewers. Empty file, no crash."""
+    matrix = torch.empty((0, 3))
+    out_path = tmp_path / 'sparse.csv'
+    generate_sparse_scores_from_matrix(matrix, [], ['r0', 'r1', 'r2'], sparse_value=10, scores_path=out_path)
+    assert out_path.exists()
+    assert out_path.read_text() == ''

--- a/tests/test_sparse_scores_from_matrix.py
+++ b/tests/test_sparse_scores_from_matrix.py
@@ -1,0 +1,182 @@
+"""Unit tests for generate_sparse_scores_from_matrix.
+
+These tests pin down three properties separately from any model-side code,
+using small synthetic score matrices:
+
+1. Top-K selection picks the (test, reviewer) pairs with the highest scores
+   along each axis, unioned across both axes.
+2. Output rows are sorted (test_id desc, score desc) — same convention as the
+   legacy tuple-based generate_sparse_scores. Consumers may depend on this
+   ordering.
+3. The new matrix-based implementation agrees with the legacy tuple-based
+   generate_sparse_scores on a random matrix (with unique scores so no ties).
+"""
+import csv
+import torch
+import pytest
+from expertise.utils.utils import (
+    generate_sparse_scores,
+    generate_sparse_scores_from_matrix,
+)
+
+
+def _read_csv_rows(path):
+    """Read sparse CSV back as list[(test_id, reviewer_id, score)]."""
+    rows = []
+    with open(path) as f:
+        for row in csv.reader(f):
+            if len(row) >= 3:
+                rows.append((row[0], row[1], float(row[2])))
+    return rows
+
+
+def _legacy_sparse_pairs(matrix, test_ids, reviewer_ids, sparse_value, scores_path):
+    """Run legacy tuple-based generate_sparse_scores on the equivalent
+    flattened (test, reviewer, score) list. Returns the set of (test_id,
+    reviewer_id) pairs.
+
+    The legacy function mutates the input list and uses `round` on the way out
+    to the CSV; we mirror that by re-reading from the CSV.
+    """
+    scores = matrix.tolist()
+    flat = []
+    for i, t in enumerate(test_ids):
+        for j, r in enumerate(reviewer_ids):
+            flat.append((t, r, round(scores[i][j], 4)))
+    generate_sparse_scores(flat, sparse_value, scores_path)
+    return {(row[0], row[1]) for row in _read_csv_rows(scores_path)}
+
+
+def test_top_k_selection(tmp_path):
+    """Top-1 per row + top-1 per column on a 3x3 matrix. Verify the
+    union of (max-per-row, max-per-column) pairs is emitted. Crafted so
+    row-max and column-max pick different (test, reviewer) pairs."""
+    matrix = torch.tensor([
+        [0.9, 0.1, 0.2],   # row max: r0
+        [0.8, 0.4, 0.3],   # row max: r0
+        [0.7, 0.6, 0.5],   # row max: r0
+    ])
+    test_ids = ['t0', 't1', 't2']
+    reviewer_ids = ['r0', 'r1', 'r2']
+
+    out_path = tmp_path / 'sparse.csv'
+    generate_sparse_scores_from_matrix(matrix, test_ids, reviewer_ids, sparse_value=1, scores_path=out_path)
+    rows = _read_csv_rows(out_path)
+    pairs = {(t, r) for t, r, _ in rows}
+
+    # Top-1 per row picks r0 for every test paper:
+    #   (t0,r0), (t1,r0), (t2,r0)
+    # Top-1 per col picks the row-max for each column:
+    #   r0->t0 (0.9), r1->t2 (0.6), r2->t2 (0.5)
+    #   -> (t0,r0), (t2,r1), (t2,r2)
+    expected = {('t0', 'r0'), ('t1', 'r0'), ('t2', 'r0'), ('t2', 'r1'), ('t2', 'r2')}
+    assert pairs == expected
+
+
+def test_output_ordering_matches_legacy(tmp_path):
+    """Output is sorted (test_id desc, score desc) to match legacy output."""
+    matrix = torch.tensor([
+        [0.10, 0.20, 0.30],
+        [0.40, 0.50, 0.60],
+        [0.70, 0.80, 0.90],
+    ])
+    test_ids = ['aaa', 'mmm', 'zzz']           # alphabetical
+    reviewer_ids = ['r0', 'r1', 'r2']
+
+    out_path = tmp_path / 'sparse.csv'
+    # sparse_value=3 -> all 9 pairs included for this 3x3 matrix.
+    generate_sparse_scores_from_matrix(matrix, test_ids, reviewer_ids, sparse_value=3, scores_path=out_path)
+    rows = _read_csv_rows(out_path)
+
+    assert len(rows) == 9
+
+    # Legacy convention: sort by (test_id desc, score desc).
+    # → 'zzz' rows first (then 'mmm', then 'aaa'); within each test_id,
+    # scores descending.
+    test_id_order = [r[0] for r in rows]
+    assert test_id_order == ['zzz', 'zzz', 'zzz', 'mmm', 'mmm', 'mmm', 'aaa', 'aaa', 'aaa']
+
+    # Within each test_id, scores must be in descending order.
+    for tid in ['zzz', 'mmm', 'aaa']:
+        block = [s for t, _, s in rows if t == tid]
+        assert block == sorted(block, reverse=True), \
+            f"Scores within test_id={tid!r} not descending: {block}"
+
+
+def test_score_values_correct(tmp_path):
+    """Each emitted row carries the score from the matrix at that (test, reviewer)
+    cell (rounded to 4 decimals)."""
+    matrix = torch.tensor([
+        [0.1234, 0.5678, 0.9876],
+        [0.4321, 0.8765, 0.2109],
+    ])
+    test_ids = ['s0', 's1']
+    reviewer_ids = ['~Reviewer_A1', '~Reviewer_B1', '~Reviewer_C1']
+
+    out_path = tmp_path / 'sparse.csv'
+    generate_sparse_scores_from_matrix(matrix, test_ids, reviewer_ids, sparse_value=2, scores_path=out_path)
+    rows = _read_csv_rows(out_path)
+
+    # Build a lookup back to the source matrix for verification.
+    expected = {}
+    for i, t in enumerate(test_ids):
+        for j, r in enumerate(reviewer_ids):
+            expected[(t, r)] = round(matrix[i, j].item(), 4)
+
+    for test_id, reviewer_id, score in rows:
+        assert (test_id, reviewer_id) in expected
+        assert abs(score - expected[(test_id, reviewer_id)]) < 1e-9
+
+
+def test_sparse_value_larger_than_axis(tmp_path):
+    """When sparse_value > min(num_test, num_reviewers), the output is the
+    full matrix (clamped internally)."""
+    matrix = torch.tensor([
+        [0.1, 0.2],
+        [0.3, 0.4],
+    ])
+    test_ids = ['t0', 't1']
+    reviewer_ids = ['r0', 'r1']
+
+    out_path = tmp_path / 'sparse.csv'
+    generate_sparse_scores_from_matrix(matrix, test_ids, reviewer_ids, sparse_value=100, scores_path=out_path)
+    rows = _read_csv_rows(out_path)
+    pairs = {(t, r) for t, r, _ in rows}
+
+    assert pairs == {('t0', 'r0'), ('t0', 'r1'), ('t1', 'r0'), ('t1', 'r1')}
+
+
+def test_equivalent_to_legacy_on_random_matrix(tmp_path):
+    """On a random matrix with unique scores, the matrix-based and tuple-based
+    implementations must agree on the set of pairs they emit. (Ordering is
+    also asserted to match by sort key in test_output_ordering_matches_legacy.)
+    """
+    torch.manual_seed(0)
+    # Use a wide enough range and large enough size that ties are unlikely.
+    matrix = torch.rand((20, 30)) * 1000
+    # Ensure uniqueness — add tiny per-cell offset to break any accidental ties.
+    matrix = matrix + torch.arange(matrix.numel()).reshape(matrix.shape).float() * 1e-6
+    test_ids = [f't{i:02d}' for i in range(matrix.shape[0])]
+    reviewer_ids = [f'~Reviewer{j:03d}1' for j in range(matrix.shape[1])]
+
+    new_path = tmp_path / 'new.csv'
+    generate_sparse_scores_from_matrix(matrix, test_ids, reviewer_ids, sparse_value=5, scores_path=new_path)
+    new_pairs = {(t, r) for t, r, _ in _read_csv_rows(new_path)}
+
+    legacy_path = tmp_path / 'legacy.csv'
+    legacy_pairs = _legacy_sparse_pairs(matrix, test_ids, reviewer_ids, sparse_value=5, scores_path=legacy_path)
+
+    assert new_pairs == legacy_pairs, (
+        f"New impl picked pairs that differ from legacy.\n"
+        f"  only-in-new: {new_pairs - legacy_pairs}\n"
+        f"  only-in-legacy: {legacy_pairs - new_pairs}"
+    )
+
+
+def test_zero_sparse_value_produces_empty_file(tmp_path):
+    """sparse_value=0 emits an empty file rather than crashing."""
+    matrix = torch.tensor([[0.5, 0.7]])
+    out_path = tmp_path / 'sparse.csv'
+    generate_sparse_scores_from_matrix(matrix, ['t0'], ['r0', 'r1'], sparse_value=0, scores_path=out_path)
+    assert out_path.exists()
+    assert out_path.read_text() == ''

--- a/tests/test_sparse_scores_from_matrix.py
+++ b/tests/test_sparse_scores_from_matrix.py
@@ -73,34 +73,29 @@ def test_top_k_selection(tmp_path):
     assert pairs == expected
 
 
-def test_output_ordering_matches_legacy(tmp_path):
-    """Output is sorted (test_id desc, score desc) to match legacy output."""
+def test_output_is_deterministic(tmp_path):
+    """The function doesn't impose a particular row order on the output —
+    callers don't depend on it — but it must be deterministic across runs
+    (otherwise file-comparison or hashing of the CSV would be flaky).
+    Two invocations on the same matrix must produce byte-identical files.
+    """
     matrix = torch.tensor([
         [0.10, 0.20, 0.30],
         [0.40, 0.50, 0.60],
         [0.70, 0.80, 0.90],
     ])
-    test_ids = ['aaa', 'mmm', 'zzz']           # alphabetical
+    test_ids = ['aaa', 'mmm', 'zzz']
     reviewer_ids = ['r0', 'r1', 'r2']
 
-    out_path = tmp_path / 'sparse.csv'
-    # sparse_value=3 -> all 9 pairs included for this 3x3 matrix.
-    generate_sparse_scores_from_matrix(matrix, test_ids, reviewer_ids, sparse_value=3, scores_path=out_path)
-    rows = _read_csv_rows(out_path)
+    out_a = tmp_path / 'sparse_a.csv'
+    out_b = tmp_path / 'sparse_b.csv'
+    generate_sparse_scores_from_matrix(matrix, test_ids, reviewer_ids, sparse_value=3, scores_path=out_a)
+    generate_sparse_scores_from_matrix(matrix, test_ids, reviewer_ids, sparse_value=3, scores_path=out_b)
 
+    assert out_a.read_bytes() == out_b.read_bytes()
+    # And the contract is still: all 9 pairs present for this 3x3 matrix at k=3.
+    rows = _read_csv_rows(out_a)
     assert len(rows) == 9
-
-    # Legacy convention: sort by (test_id desc, score desc).
-    # → 'zzz' rows first (then 'mmm', then 'aaa'); within each test_id,
-    # scores descending.
-    test_id_order = [r[0] for r in rows]
-    assert test_id_order == ['zzz', 'zzz', 'zzz', 'mmm', 'mmm', 'mmm', 'aaa', 'aaa', 'aaa']
-
-    # Within each test_id, scores must be in descending order.
-    for tid in ['zzz', 'mmm', 'aaa']:
-        block = [s for t, _, s in rows if t == tid]
-        assert block == sorted(block, reverse=True), \
-            f"Scores within test_id={tid!r} not descending: {block}"
 
 
 def test_score_values_correct(tmp_path):

--- a/tests/test_sparse_scores_from_matrix.py
+++ b/tests/test_sparse_scores_from_matrix.py
@@ -173,15 +173,6 @@ def test_equivalent_to_legacy_on_random_matrix(tmp_path):
     )
 
 
-def test_zero_sparse_value_produces_empty_file(tmp_path):
-    """sparse_value=0 emits an empty file rather than crashing."""
-    matrix = torch.tensor([[0.5, 0.7]])
-    out_path = tmp_path / 'sparse.csv'
-    generate_sparse_scores_from_matrix(matrix, ['t0'], ['r0', 'r1'], sparse_value=0, scores_path=out_path)
-    assert out_path.exists()
-    assert out_path.read_text() == ''
-
-
 def test_empty_reviewer_axis_produces_empty_file(tmp_path):
     """When the model produces a [num_test, 0] matrix because no reviewers
     were eligible (every train_note_id_list empty or all publications were

--- a/tests/test_sparse_scores_from_matrix.py
+++ b/tests/test_sparse_scores_from_matrix.py
@@ -5,11 +5,14 @@ using small synthetic score matrices:
 
 1. Top-K selection picks the (test, reviewer) pairs with the highest scores
    along each axis, unioned across both axes.
-2. Output rows are sorted (test_id desc, score desc) — same convention as the
-   legacy tuple-based generate_sparse_scores. Consumers may depend on this
-   ordering.
-3. The new matrix-based implementation agrees with the legacy tuple-based
-   generate_sparse_scores on a random matrix (with unique scores so no ties).
+2. Output rows are written in deterministic order across runs. The function
+   does not promise a specific sort key — it emits whatever order
+   torch.unique returns (lexicographic on (test_idx, rev_idx) ascending) —
+   but two invocations on the same matrix must produce byte-identical files
+   so the CSV is safe to hash/diff.
+3. The new matrix-based implementation agrees on the set of emitted pairs
+   with the legacy tuple-based generate_sparse_scores on a random matrix
+   (with unique scores so no ties). Ordering is not compared.
 """
 import csv
 import torch
@@ -143,8 +146,9 @@ def test_sparse_value_larger_than_axis(tmp_path):
 
 def test_equivalent_to_legacy_on_random_matrix(tmp_path):
     """On a random matrix with unique scores, the matrix-based and tuple-based
-    implementations must agree on the set of pairs they emit. (Ordering is
-    also asserted to match by sort key in test_output_ordering_matches_legacy.)
+    implementations must agree on the set of pairs they emit. Ordering is not
+    compared — the matrix-based impl emits torch.unique's lexicographic order,
+    not the legacy (test_id desc, score desc) sort.
     """
     torch.manual_seed(0)
     # Use a wide enough range and large enough size that ties are unlikely.

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -10,7 +10,30 @@ import torch
 from expertise.dataset import ArchivesDataset, SubmissionsDataset
 from expertise.models import specter2_scincl
 import redisai
-from expertise.utils.utils import generate_sparse_scores
+from expertise.utils.utils import generate_sparse_scores_from_matrix
+
+
+def _matrix_to_rows_and_csv(model, csv_path=None):
+    """Test adapter: flatten the new matrix-based model output into the
+    legacy [(test_id, reviewer_id, score), ...] tuple list, and optionally
+    write the equivalent CSV file. Used by tests that previously consumed
+    the per-row CSV/preliminary_scores produced by all_scores().
+    Scores are rounded to 4 decimals at the row boundary — fp32 storage in
+    the matrix preserves at most ~7 significant digits, so the per-cell
+    Python round matches what the legacy code emitted in the CSV.
+    """
+    rows = []
+    if model.scores_matrix is None:
+        return rows
+    scores = model.scores_matrix.tolist()
+    for i, test_id in enumerate(model.test_id_list):
+        for j, reviewer_id in enumerate(model.reviewer_ids):
+            rows.append((test_id, reviewer_id, round(scores[i][j], 4)))
+    if csv_path is not None:
+        with open(csv_path, 'w') as f:
+            for test_id, reviewer_id, score in rows:
+                f.write(f'{test_id},{reviewer_id},{score}\n')
+    return rows
 
 
 def compute_score_statistics(scores, label=""):
@@ -124,15 +147,17 @@ def test_specncl_scores(tmp_path, create_specncl):
 
     scores_path = tmp_path / 'scores'
     scores_path.mkdir()
-    all_scores = specnclModel.all_scores(
+    specnclModel.all_scores(
         specter_publications_path=publications_path.joinpath('pub2vec_specter.jsonl'),
         scincl_publications_path=publications_path.joinpath('pub2vec_scincl.jsonl'),
         specter_submissions_path=submissions_path.joinpath('sub2vec_specter.jsonl'),
         scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.jsonl'),
-        scores_path=scores_path.joinpath(config['name'] + '.csv')
+        matrix_path=scores_path.joinpath(config['name'] + '.pt')
     )
 
-    assert_scores_have_max_4_decimals(scores_path.joinpath(config['name'] + '.csv'))
+    csv_path = scores_path.joinpath(config['name'] + '.csv')
+    _matrix_to_rows_and_csv(specnclModel, csv_path=csv_path)
+    assert_scores_have_max_4_decimals(csv_path)
 
 
 def test_sparse_scores(tmp_path, create_specncl):
@@ -167,23 +192,40 @@ def test_sparse_scores(tmp_path, create_specncl):
 
     scores_path = tmp_path / 'scores'
     scores_path.mkdir()
-    all_scores = specnclModel.all_scores(
+    specnclModel.all_scores(
         specter_publications_path=publications_path.joinpath('pub2vec_specter.jsonl'),
         scincl_publications_path=publications_path.joinpath('pub2vec_scincl.jsonl'),
         specter_submissions_path=submissions_path.joinpath('sub2vec_specter.jsonl'),
         scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.jsonl'),
-        scores_path=scores_path.joinpath(config['name'] + '.csv')
+        matrix_path=scores_path.joinpath(config['name'] + '.pt')
     )
 
+    full_csv = scores_path.joinpath(config['name'] + '.csv')
+    _matrix_to_rows_and_csv(specnclModel, csv_path=full_csv)
+
+    sparse_csv = scores_path.joinpath(config['name'] + '_sparse.csv')
     if config['model_params'].get('sparse_value'):
-        all_scores = generate_sparse_scores(all_scores, config['model_params']['sparse_value'], scores_path.joinpath(config['name'] + '_sparse.csv'))
+        generate_sparse_scores_from_matrix(
+            specnclModel.scores_matrix,
+            specnclModel.test_id_list,
+            specnclModel.reviewer_ids,
+            config['model_params']['sparse_value'],
+            sparse_csv,
+        )
 
-    assert_scores_have_max_4_decimals(scores_path.joinpath(config['name'] + '.csv'))
-    assert_scores_have_max_4_decimals(scores_path.joinpath(config['name'] + '_sparse.csv'))
+    assert_scores_have_max_4_decimals(full_csv)
+    assert_scores_have_max_4_decimals(sparse_csv)
 
-    assert len(all_scores) == 8
-    for row in all_scores:
-        submission_id, profile_id, score = row[0], row[1], float(row[2])
+    # Read sparse CSV back into rows for assertions.
+    sparse_rows = []
+    with open(sparse_csv) as f:
+        for line in f:
+            parts = line.strip().split(',')
+            if len(parts) >= 3:
+                sparse_rows.append((parts[0], parts[1], float(parts[2])))
+
+    assert len(sparse_rows) == 8
+    for submission_id, profile_id, score in sparse_rows:
         assert len(submission_id) >= 1
         assert len(profile_id) >= 1
         assert profile_id.startswith('~')
@@ -224,13 +266,14 @@ def test_normalization(tmp_path, create_specncl):
 
     scores_path = unnorm_path / 'scores'
     scores_path.mkdir()
-    all_scores = specnclModel.all_scores(
+    specnclModel.all_scores(
         specter_publications_path=publications_path.joinpath('pub2vec_specter.jsonl'),
         scincl_publications_path=publications_path.joinpath('pub2vec_scincl.jsonl'),
         specter_submissions_path=submissions_path.joinpath('sub2vec_specter.jsonl'),
         scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.jsonl'),
-        scores_path=scores_path.joinpath(config['name'] + '.csv')
+        matrix_path=scores_path.joinpath(config['name'] + '.pt')
     )
+    all_scores = _matrix_to_rows_and_csv(specnclModel)
 
     for row in all_scores:
         submission_id, profile_id, score = row[0], row[1], float(row[2])
@@ -238,7 +281,7 @@ def test_normalization(tmp_path, create_specncl):
         assert len(profile_id) >= 1
         assert profile_id.startswith('~')
         assert score >= 0 and score <= 1
-    
+
     # Compute statistics for unnormalized scores
     unnorm_stats = compute_score_statistics(all_scores, "(Unnormalized)")
     
@@ -275,20 +318,21 @@ def test_normalization(tmp_path, create_specncl):
 
     scores_path = norm_path / 'scores'
     scores_path.mkdir()
-    all_scores = specnclModel.all_scores(
+    specnclModel.all_scores(
         specter_publications_path=publications_path.joinpath('pub2vec_specter.jsonl'),
         scincl_publications_path=publications_path.joinpath('pub2vec_scincl.jsonl'),
         specter_submissions_path=submissions_path.joinpath('sub2vec_specter.jsonl'),
         scincl_submissions_path=submissions_path.joinpath('sub2vec_scincl.jsonl'),
-        scores_path=scores_path.joinpath(config['name'] + '.csv')
+        matrix_path=scores_path.joinpath(config['name'] + '.pt')
     )
+    all_scores = _matrix_to_rows_and_csv(specnclModel)
 
     for row in all_scores:
         submission_id, profile_id, score = row[0], row[1], float(row[2])
         assert len(submission_id) >= 1
         assert len(profile_id) >= 1
         assert profile_id.startswith('~')
-        assert score >= 0 and score <= 1    
+        assert score >= 0 and score <= 1
     # Compute statistics for normalized scores
     norm_stats = compute_score_statistics(all_scores, "(Normalized)")
 
@@ -406,13 +450,14 @@ def test_self_similarity_score_within_bounds(tmp_path):
     scores_dir = tmp_path / "scores"
     scores_dir.mkdir()
 
-    all_scores = model.all_scores(
+    model.all_scores(
         specter_publications_path=specter_pub_path,
         scincl_publications_path=scincl_pub_path,
         specter_submissions_path=specter_sub_path,
         scincl_submissions_path=scincl_sub_path,
-        scores_path=scores_dir / "test_self_similarity.csv",
+        matrix_path=scores_dir / "test_self_similarity.pt",
     )
+    all_scores = _matrix_to_rows_and_csv(model)
 
     assert len(all_scores) > 0, "No scores were produced — check dataset setup."
 
@@ -618,14 +663,14 @@ def test_venue_specific_weights_with_weightless_cache(tmp_path):
     assert specter_pub_path.read_text() == specter_cache.read_text()
     assert scincl_pub_path.read_text() == scincl_cache.read_text()
 
-    scores_path = work_dir / "scores.csv"
-    scores = model.all_scores(
+    matrix_path = work_dir / "scores.pt"
+    model.all_scores(
         specter_publications_path=specter_pub_path,
         scincl_publications_path=scincl_pub_path,
         specter_submissions_path=specter_sub_path,
         scincl_submissions_path=scincl_sub_path,
-        scores_path=scores_path,
+        matrix_path=matrix_path,
     )
 
-    assert scores, "Expected at least one score row"
-    assert scores_path.exists()
+    assert model.scores_matrix is not None and model.scores_matrix.numel() > 0, "Expected at least one score row"
+    assert matrix_path.exists()

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -674,3 +674,93 @@ def test_venue_specific_weights_with_weightless_cache(tmp_path):
 
     assert model.scores_matrix is not None and model.scores_matrix.numel() > 0, "Expected at least one score row"
     assert matrix_path.exists()
+
+
+def test_all_scores_skips_reviewer_with_only_bad_embeddings(tmp_path):
+    """Regression: when every publication for a reviewer has a zero-length
+    embedding (added to train_bad_id_set by load_emb_file), train_paper_idx
+    becomes empty. The previous code would slice p2p_aff_norm[:, []] and crash
+    on .max(dim=1)[0] / torch.quantile, or produce NaNs from .mean(dim=1).
+    Expected: the reviewer is skipped and the run completes successfully
+    with that reviewer omitted from scores_matrix's columns.
+
+    Setup: two reviewers — one with a good paper, one whose only paper has
+    a zero-length embedding. The bad-embedding reviewer must not appear in
+    the resulting reviewer_ids; the good-embedding reviewer must.
+    """
+    archive_dir = tmp_path / "archives"
+    archive_dir.mkdir()
+    (archive_dir / "~GoodReviewer1.jsonl").write_text(
+        json.dumps({"id": "good_paper", "content": {"title": "Good Paper", "abstract": "Abstract."}}) + "\n"
+    )
+    (archive_dir / "~BadReviewer1.jsonl").write_text(
+        json.dumps({"id": "bad_paper", "content": {"title": "Bad Paper", "abstract": "Abstract."}}) + "\n"
+    )
+
+    submissions_dir = tmp_path / "submissions"
+    submissions_dir.mkdir()
+    (submissions_dir / "Sub1.jsonl").write_text(
+        json.dumps({"id": "Sub1", "content": {"title": "Submission", "abstract": "Submission abstract."}}) + "\n"
+    )
+
+    archives_dataset = ArchivesDataset(archives_path=archive_dir)
+    submissions_dataset = SubmissionsDataset(submissions_path=submissions_dir)
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    model = specter2_scincl.EnsembleModel(
+        specter_dir="../expertise-utils/specter/",
+        work_dir=str(work_dir),
+        average_score=True,
+        max_score=False,
+        use_cuda=False,
+        use_redis=False,
+    )
+    model.set_archives_dataset(archives_dataset)
+    model.set_submissions_dataset(submissions_dataset)
+
+    pub_dir = tmp_path / "publications"
+    pub_dir.mkdir()
+    sub_dir = tmp_path / "sub_embeddings"
+    sub_dir.mkdir()
+    specter_pub_path = pub_dir / "pub2vec_specter.jsonl"
+    scincl_pub_path  = pub_dir / "pub2vec_scincl.jsonl"
+    specter_sub_path = sub_dir / "sub2vec_specter.jsonl"
+    scincl_sub_path  = sub_dir / "sub2vec_scincl.jsonl"
+
+    # Write hand-crafted embeddings. The "bad_paper" gets an empty embedding
+    # ([]), which load_emb_file detects (paper_emb_size == 0) and adds to
+    # train_bad_id_set. ~BadReviewer1's only paper is bad — so their
+    # train_paper_idx will be empty after filtering.
+    good_embedding = [0.1] * 768
+    pub_lines = (
+        json.dumps({"paper_id": "good_paper", "embedding": good_embedding}) + "\n"
+        + json.dumps({"paper_id": "bad_paper", "embedding": []}) + "\n"
+    )
+    specter_pub_path.write_text(pub_lines)
+    scincl_pub_path.write_text(pub_lines)
+
+    sub_emb = [0.2] * 768
+    sub_line = json.dumps({"paper_id": "Sub1", "embedding": sub_emb}) + "\n"
+    specter_sub_path.write_text(sub_line)
+    scincl_sub_path.write_text(sub_line)
+
+    scores_dir = tmp_path / "scores"
+    scores_dir.mkdir()
+    # Must not raise.
+    model.all_scores(
+        specter_publications_path=specter_pub_path,
+        scincl_publications_path=scincl_pub_path,
+        specter_submissions_path=specter_sub_path,
+        scincl_submissions_path=scincl_sub_path,
+        matrix_path=scores_dir / "scores.pt",
+    )
+
+    # The good reviewer is present; the bad-only reviewer is dropped.
+    assert "~GoodReviewer1" in model.reviewer_ids
+    assert "~BadReviewer1" not in model.reviewer_ids
+    # Matrix shape: [num_test=1, num_reviewers=1].
+    assert tuple(model.scores_matrix.shape) == (1, 1)
+    # Score is finite (no NaN from a degenerate reduction).
+    score = model.scores_matrix[0, 0].item()
+    assert score == score, "Score must not be NaN"


### PR DESCRIPTION
## Summary

The score pipeline used to flatten `[num_test × num_reviewers]` similarity scores into a 175M-tuple Python list (`preliminary_scores`) and then run two `list.sort(key=lambda)` passes to compute the sparse top-N. On large jobs (e.g. 35k submissions × ~5k reviewers) that took **~2.5 hours per cycle** and held ~17 GB of Python tuples in memory.

This PR makes three coordinated changes:

1. **Storage refactor.** Scoring keeps a `torch.Tensor` of shape `[num_test, num_reviewers]` in memory and persists it to `{name}.pt` via `torch.save`. Replaces the full `{name}.csv` (no longer written). The dense matrix is also what every other phase now consumes.
2. **Sparse generation via `torch.topk`.** New `generate_sparse_scores_from_matrix(...)` uses `torch.topk` on both axes, vectorized union/dedupe, and a chunked CSV write. Single-digit seconds for the same data that took 2.5 hours before. Output order is `torch.unique`'s lexicographic `(test_idx, rev_idx)` ascending — deterministic across runs but **not** the legacy `(note_id desc, score desc)` sort. The final Python sort is intentionally dropped because `/expertise/results` consumers re-sort/filter on read and don't depend on file order; paying an O(N log N) sort over ~16M tuples at production scale was the dominant remaining cost.
3. **CSV-everywhere storage + opt-in CSV API response.** Pipeline now uploads the sparse CSV to GCS as-is (no more CSV→JSONL transform on upload). Cloud reader handles CSV (new) and JSONL (legacy in-flight jobs). New optional `?format=csv` on `/expertise/results` lets clients receive raw CSV when they're ready to migrate. JSON remains the default.

API contract for clients is unchanged: the default `/expertise/results` response is still the same JSON envelope. Same values, same shape.

## Why

After the previous OOM PR, the next dominant bottleneck was `generate_sparse_scores` doing `list.sort(key=lambda x: (x[0], x[2]), reverse=True)` over 175M Python tuples — twice. Each sort calls the lambda once per item; that's ~350M Python frames per call and ~17 GB of tuple memory. `torch.topk` on a 700 MB dense matrix runs in single-digit seconds for the same data.

Storing the score matrix as a `.pt` file also gives us "the full table is on disk, in a compact format, in case we ever need to re-query it" — without paying the cost of the 175M-row full-scores CSV that used to live alongside the sparse one.

The CSV-to-JSONL conversion on upload was burning CPU and ~2× the GCS bytes for no functional reason — every consumer parsed the JSONL back into dicts anyway. Storing CSV directly halves the bytes and skips the upload-time serialization.

## Changes

### 1. Models build a score matrix instead of `preliminary_scores`

**Files:** [`specter2_scincl/specter.py`](expertise/models/specter2_scincl/specter.py), [`specter2_scincl/scincl.py`](expertise/models/specter2_scincl/scincl.py)

Inside the per-reviewer loop, each `all_paper_aff` vector is appended to a list and the loop ends with `torch.stack(score_vectors, dim=1)` to produce a `[num_test, num_reviewers]` tensor. The model exposes:

```python
self.scores_matrix    # torch.Tensor [num_test, num_reviewers]
self.test_id_list     # list[str]
self.reviewer_ids     # list[str]
```

The `csv_scores` list, the per-row `self.preliminary_scores.append(...)` loop with `.item()` × 175M, and the `with open(scores_path) as f: f.write(...)` for the full CSV are all gone.

If the caller passes a `matrix_path`, the model also saves a single bundled file:

```python
torch.save({
    'scores': self.scores_matrix,
    'test_ids': self.test_id_list,
    'reviewer_ids': self.reviewer_ids,
}, matrix_path)
```

**Empty-reviewer edge case:** when no reviewer is eligible (every `train_note_id_list` is empty or all publications got dropped via `bad_id_set`), the model now constructs a `[num_test, 0]` tensor and empty `reviewer_ids` list — matching pre-refactor behavior of "produce empty result, don't crash". Previously a naive `torch.stack` on an empty list would raise.

For `compute_paper_paper` mode the matrix is the full `[num_test, num_train]` p2p tensor; column ids are train paper ids rather than reviewer ids. (At very large scale this tensor — e.g. 70 GB for 35k × 500k — won't fit in memory for `torch.save`; chunked save is a separate TODO.)

### 2. Ensemble merges matrices instead of tuples

**File:** [`specter2_scincl/ensemble.py`](expertise/models/specter2_scincl/ensemble.py)

The old code merged `(test_id, reviewer_id, score)` tuples one at a time:

```python
specter_preliminary_scores_map = {}
for entry in self.specter_predictor.preliminary_scores:
    specter_preliminary_scores_map[(entry[0], entry[1])] = entry[2]
for entry in self.scincl_predictor.preliminary_scores:
    new_score = specter_preliminary_scores_map[(entry[0], entry[1])] * α + entry[2] * (1 - α)
    ...
```

That's ~350M Python iterations for a job at the user's scale. Replaced with a vectorized matrix-level merge:

```python
merged = self.specter_predictor.scores_matrix * α + self.scincl_predictor.scores_matrix * (1 - α)
if self.normalize_scores:
    merged = torch.clamp(merged, 0.0, 1.0)
else:
    merged = torch.clamp(merged, -1.0, 1.0)
merged = (merged * 10000).round() / 10000
```

Components are called with `matrix_path=None` (no per-component file on disk); only the merged matrix is persisted.

### 3. Matrix-based sparse generator (new ordering contract)

**File:** [`utils/utils.py`](expertise/utils/utils.py) — new `generate_sparse_scores_from_matrix(scores_matrix, test_id_list, reviewer_ids, sparse_value, scores_path)`

```python
_, top_rev_per_test = torch.topk(scores_matrix, k=k_cols, dim=1)   # [n_test, k]
_, top_test_per_rev = torch.topk(scores_matrix, k=k_rows, dim=0)   # [k, n_rev]

test_ar = torch.arange(n_test).unsqueeze(1).expand(-1, k_cols).flatten()
pairs_a = torch.stack([test_ar, top_rev_per_test.flatten()], dim=1)

rev_ar = torch.arange(n_rev).unsqueeze(0).expand(k_rows, -1).flatten()
pairs_b = torch.stack([top_test_per_rev.flatten(), rev_ar], dim=1)

all_pairs = torch.unique(torch.cat([pairs_a, pairs_b], dim=0), dim=0)
sel_scores = scores_matrix[all_pairs[:, 0], all_pairs[:, 1]].cpu()
all_pairs = all_pairs.cpu()

# Chunked CSV write — keeps tensors in tensor form and only materializes
# one chunk of Python objects at a time (bounded peak memory at ~16M pairs).
chunk_size = 1_000_000
with open(scores_path, 'w') as f:
    for start in range(0, int(all_pairs.shape[0]), chunk_size):
        end = min(start + chunk_size, all_pairs.shape[0])
        chunk_pairs = all_pairs[start:end].tolist()
        chunk_scores = sel_scores[start:end].tolist()
        for (i, j), score in zip(chunk_pairs, chunk_scores):
            f.write(f'{test_id_list[i]},{reviewer_ids[j]},{round(score, 4)}\n')
```

`torch.topk` does an O(N log k) partial sort (single-digit seconds for the full 35k × 5k matrix at k=400). Chunked iteration over CPU tensors avoids materializing the full ~16M Python-object pair list (>1 GB of boxed objects) all at once.

**Ordering contract — changed from legacy.** The legacy `generate_sparse_scores` ends with `sorted(..., key=lambda x: (x[0], x[2]), reverse=True)` — `(note_id desc, score desc)`. The new function deliberately drops that final sort and writes rows in `torch.unique`'s lexicographic `(test_idx, rev_idx)` ascending order. Two invocations on the same matrix produce byte-identical files (so CSV diff/hash is still safe), but the on-disk row order differs from pre-refactor sparse files. The `/expertise/results` route already re-sorts on read and consumers don't depend on file order, so this is safe to change; the win is skipping the O(N log N) Python sort over millions of tuples — the biggest remaining cost after `torch.topk`.

`round(score, 4)` is applied at the CSV boundary because fp32 storage in the matrix can't preserve exact 4-decimal values (e.g. 0.468 stored as fp32 prints as `0.46799999475479126` in fp64).

The legacy tuple-based `generate_sparse_scores` is kept untouched for `aggregate_by_group` and BM25/MFR/specter+mfr which still produce tuple lists.

### 4. `sparse_value` is a required positive integer

**File:** [`service/utils.py`](expertise/service/utils.py)

Two changes:

- **Default unified at 400.** The local service default (`300`) and the pipeline default (`600`) both moved to 400. One canonical default.
- **Validation at config creation.** If a request supplies `sparseValue` that isn't a positive integer, the config validator raises `Bad request: 'sparseValue' must be a positive integer, got X`. The route handler converts this to HTTP 400 — the worker never sees a malformed value.

```python
sparse_value = config.model_params.get('sparse_value')
if not isinstance(sparse_value, int) or sparse_value <= 0:
    raise openreview.OpenReviewException(
        f"Bad request: 'sparseValue' must be a positive integer, got {sparse_value!r}"
    )
```

Downstream code in `execute_expertise.py` and `service/expertise.py` is correspondingly simpler — `sparse_value` is now an invariant, no defensive `is not None` / `> 0` checks needed.

### 5. CSV-everywhere on the cloud path (no more upload-time JSONL conversion)

**File:** [`execute_pipeline.py`](expertise/execute_pipeline.py)

The pipeline used to read each `.csv` from the worker disk and rewrite it as `.jsonl` while streaming to GCS (parse + `json.dumps` per row, with an `entityA`/`entityB` swap for mixed Group/Note matching). Now it just uploads the CSV as-is:

```python
for csv_file in [d for d in os.listdir(config.job_dir) if d.endswith('.csv')]:
    dest_name = 'scores_sparse.csv' if '_sparse' in csv_file else 'scores.csv'
    blob = bucket.blob(f"{blob_prefix}/{dest_name}")
    blob.upload_from_filename(os.path.join(config.job_dir, csv_file))
```

Wins:
- Zero per-row CPU work at upload (was `json.dumps` 24M times + a conditional column swap).
- ~half the bytes in GCS (no per-row JSON field names `entityA, entityB, score`).
- The `entityA`/`entityB` swap moves to read time in the cloud reader (where the local service has always done it) — unifies the two service implementations.

`.pt` files (the dense score matrix) are uploaded via the same direct-streaming pattern.

### 6. Cloud reader handles CSV + legacy JSONL

**File:** [`service/utils.py`](expertise/service/utils.py)

`stream_score_file` now dispatches on blob extension:

- `.csv` (new): `csv.reader` → dicts, with the matching-type-aware `entityA`/`entityB` swap (symmetric → cols 0/1; mixed → swap 0/1).
- `.jsonl` (legacy in-flight jobs created before this PR): `json.loads` per line → dict consumed as-is.

Matching type is computed once from the authenticated request blob and passed into the inner generator. The dict shape downstream is identical for both formats, so the route handler is agnostic.

### 7. Local service simplified: `get_results` always serves sparse

**File:** [`service/expertise.py`](expertise/service/expertise.py)

`_get_score_and_metadata_dir` previously had a layered lookup involving the full CSV and `.pt` file. Since `sparse_value` is now required, every successful job produces `{name}_sparse.csv` — the lookup is one line:

```python
if not os.path.isfile(sparse_csv_path):
    raise OpenReviewException("Sparse score file not found ...")
file_dir = sparse_csv_path
```

No more legacy-fallback branches, no more `.pt` fallback, no `sparse_requested` check. If sparse is missing, error explicitly rather than silently serving an alternate artifact.

### 8. New `?format=csv` on `/expertise/results`

**File:** [`service/routes.py`](expertise/service/routes.py)

Clients can now request results as CSV instead of JSON:

| Request | Response | Mimetype |
|---|---|---|
| `GET /expertise/results?jobId=X` | `{"results":[{"entityA":..., "entityB":..., "score":...}, ...], "metadata":{...}}` | `application/json` |
| `GET /expertise/results?jobId=X&format=csv` | Header `entityA,entityB,score` + one row per result | `text/csv` |

Default stays JSON — existing clients keep working with no changes. The route handler normalizes both service shapes (cloud=generator-of-chunks, local=dict) into a single iterable of result-item dicts, then either:
- `format=json`: serializes via `json.dumps` per row, wrapped in the standard envelope.
- `format=csv`: streams via `csv.writer` in ~8 KB chunks.

CSV response has no metadata (CSV has no place for it). Clients that need metadata stay on JSON, or do a separate `?format=json` call.

### 9. Dispatch in `execute_expertise.py`

Matrix-based models (`specter2`, `scincl`, `specter2+scincl`) get `matrix_path={name}.pt` passed to `all_scores()`. Sparse generation chooses the path:

```python
sparse_value = config['model_params']['sparse_value']  # always present (validated)
sparse_path = Path(...) / f"{config['name']}_sparse.csv"
if 'alternate_match_group' in config.keys():
    preliminary_scores = aggregate_by_group(config)
    generate_sparse_scores(preliminary_scores, sparse_value, sparse_path)
elif getattr(predictor, 'scores_matrix', None) is not None:
    generate_sparse_scores_from_matrix(
        predictor.scores_matrix, predictor.test_id_list, predictor.reviewer_ids,
        sparse_value, sparse_path,
    )
else:
    generate_sparse_scores(predictor.preliminary_scores, sparse_value, sparse_path)
```

### 10. `multifacet_recommender/specter.py` left on the legacy `preliminary_scores` path

That predictor is consumed by the `specter+mfr` ensemble, which merges per-tuple with MFR's preliminary_scores. Migrating it to the matrix path would require also refactoring MFR + the multifacet ensemble — out of scope for this PR.

## Performance impact (estimated, for the user's job size: 35k × 5k reviewers, sparse_value=400)

| Phase | Before | After |
|---|---|---|
| `preliminary_scores` build (inner `.item()` loop) | ~10–15 min, ~17 GB Python tuples | ~0 (skipped; matrix is the data) |
| Ensemble merge (175M-iteration Python loop) | ~5–10 min, ~30 GB total | milliseconds, vectorized |
| Sparse score generation (2× `list.sort(key=lambda)` + sets + final sort) | **~2.5 h per cycle** | seconds to single-digit minutes |
| Full-scores CSV write (175M lines) | ~minutes, ~20 GB disk | not produced |
| Pipeline upload (CSV → JSONL conversion + write) | ~minutes, CPU-bound | ~seconds, network-bound (`upload_from_filename`) |
| GCS storage: `{name}_sparse.{ext}` | `~120 MB` (JSONL) | `~60 MB` (CSV) |
| Disk: `{name}.csv` | ~20 GB | **gone** |
| Disk: `{name}.pt` | n/a | ~700 MB (compact fp32 matrix + id lists) |

Legacy code paths (BM25, MFR, specter+mfr, `alternate_match_group`) are unchanged.

## Tests

- [x] **[`tests/test_sparse_scores_from_matrix.py`](tests/test_sparse_scores_from_matrix.py)** *(new)* — unit tests on synthetic matrices:
  - Top-K selection picks the correct (test, reviewer) pairs.
  - Output is **deterministic** (byte-identical across runs) — does **not** assert legacy `(test_id desc, score desc)` order; the new contract is `torch.unique` lexicographic ascending.
  - Score values correct (matrix value, rounded to 4 decimals).
  - `sparse_value > min(num_test, num_reviewers)`: clamped internally, full matrix emitted.
  - **Pair-set equivalence with legacy** `generate_sparse_scores` on a 20×30 random matrix with unique scores — same set of emitted pairs (ordering not compared).
  - Empty reviewer axis (`[3, 0]` matrix) and empty test axis (`[0, 3]` matrix) → empty file, no crash.
- [x] `tests/test_specter2scincl.py` — 6/6 pass (uses new `_matrix_to_rows_and_csv` adapter to validate row contents; sparse test now uses `generate_sparse_scores_from_matrix`).
- [x] `tests/test_spectermfr.py` — 2/2 pass (legacy multifacet path unchanged).
- [x] `tests/test_scoring_precision.py` — 3/3 pass.
- [x] **`tests/test_expertise_apiv2.py::test_specter2_scincl`** — now also asserts the new `?format=csv` API returns the **same values** as the default JSON response (pair-set + score equivalence within 1e-9).
- [x] `tests/test_expertise_service.py` — three tests updated to expect HTTP 400 on bad `sparseValue` (the validation now rejects at submit time; previously the test waited for the worker to crash at runtime).
- [ ] `tests/test_pipeline.py` and `tests/test_expertise_cloud_service.py` — need GCS auth (CI-only locally). Worth running once before merging.
- [ ] Smoke: large-job replay in staging — confirm sparse generation finishes in minutes and `{name}.pt` + `scores_sparse.csv` land in GCS.

## Migration notes

- **New on-disk artifact** in `config.job_dir`: `{name}.pt` (replaces `{name}.csv`). Loadable with `torch.load(path)` → dict of `{'scores': Tensor, 'test_ids': list, 'reviewer_ids': list}`.
- **New GCS object format** for new jobs: `scores_sparse.csv` (legacy `scores_sparse.jsonl` blobs for in-flight jobs still work — the cloud reader dispatches on extension).
- **API contract unchanged by default.** `/expertise/results` still returns JSON. The new `?format=csv` param is opt-in.
- **Sparse CSV row order changed.** New files are written in `torch.unique`'s lexicographic `(test_idx, rev_idx)` ascending order, not the legacy `(note_id desc, score desc)`. Deterministic across runs but **not** byte-equal to pre-refactor sparse files for the same job. Any client that did its own `head`/awk-style inspection of file order on disk needs to re-sort itself.
- **`sparseValue` is required.** Requests that supply a non-positive-integer (string, 0, negative) now get HTTP 400 at submit time. Default is **400** if not supplied (was 300 locally, 600 in pipeline — now unified).
- **`predictor.preliminary_scores`** is no longer populated for `specter2` / `scincl` / `specter2+scincl`. Any external code that read `predictor.preliminary_scores` from those models should switch to `predictor.scores_matrix` (or call the sparse function and read the CSV).
