### PR TITLE
Vectorize reviewer aggregation with bulk gather and dim=2 reduction

### DIFF
--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -301,41 +301,53 @@ class SciNCLPredictor(Predictor):
                     csv_scores.append(csv_line)
                     self.preliminary_scores.append((test_id_list[j], train_id_list[i], round(p2p_aff_norm[j, i].item(), 4)))
         else:
+            reviewer_ids = []
+            reviewer_paper_indices = []
             for reviewer_id, train_note_id_list in self.pub_author_ids_to_note_id.items():
                 if len(train_note_id_list) == 0:
                     continue
-                train_paper_idx = []
-                for paper_id in train_note_id_list:
-                    if paper_id not in train_bad_id_set:
-                        train_paper_idx.append(paper_id2train_idx[paper_id])
-                train_paper_aff_j = p2p_aff_norm[:, train_paper_idx]
+                valid = [paper_id2train_idx[pid] for pid in train_note_id_list if pid not in train_bad_id_set]
+                if not valid:
+                    continue
+                reviewer_ids.append(reviewer_id)
+                reviewer_paper_indices.append(valid)
 
-                # Apply venue-specific weights per reviewer
+            if reviewer_ids:
+                max_papers = max(len(papers) for papers in reviewer_paper_indices)
+                num_reviewers = len(reviewer_ids)
+                paper_idx = torch.zeros((num_reviewers, max_papers), dtype=torch.long)
+                mask = torch.zeros((num_reviewers, max_papers), dtype=torch.bool)
+                for r, papers in enumerate(reviewer_paper_indices):
+                    paper_idx[r, :len(papers)] = torch.tensor(papers, dtype=torch.long)
+                    mask[r, :len(papers)] = True
+
+                scores = p2p_aff_norm[:, paper_idx]  # (num_test, num_reviewers, max_papers)
+
                 if self.venue_specific_weights:
-                    train_weight_j = train_weight_tensor[train_paper_idx]
-                    # Logit-space transformation preserves bounds and probability mass
-                    epsilon = 1e-8 ## Numerical stability
-                    logits = torch.logit(train_paper_aff_j, eps=epsilon)
-                    weighted_logits = logits + torch.log(torch.clamp(train_weight_j, min=epsilon)).unsqueeze(0)
-                    train_paper_aff_j = torch.sigmoid(weighted_logits)
+                    weights = train_weight_tensor[paper_idx]
+                    epsilon = 1e-8
+                    logits = torch.logit(scores, eps=epsilon)
+                    log_w = torch.log(torch.clamp(weights, min=epsilon))
+                    scores = torch.sigmoid(logits + log_w.unsqueeze(0))
 
                 if self.percentile_select is not None:
-                    # Select score based on percentile
-                    # q=1.0 (percentile_select=100) -> max score
-                    # q=0.5 (percentile_select=50) -> median score
-                    # q=0.0 (percentile_select=0) -> min score
-                    q = self.percentile_select / 100.0
-                    q = max(0.0, min(1.0, q)) 
-                    all_paper_aff = torch.quantile(train_paper_aff_j, q, dim=1, interpolation='linear')
+                    q = max(0.0, min(1.0, self.percentile_select / 100.0))
+                    nan_scores = scores.masked_fill(~mask.unsqueeze(0), float('nan'))
+                    all_paper_aff = torch.nanquantile(nan_scores, q, dim=2, interpolation='linear')
                 elif self.average_score:
-                    all_paper_aff = train_paper_aff_j.mean(dim=1)
+                    zero_scores = scores.masked_fill(~mask.unsqueeze(0), 0.0)
+                    counts = mask.sum(dim=1).clamp(min=1).to(scores.dtype)
+                    all_paper_aff = zero_scores.sum(dim=2) / counts.unsqueeze(0)
                 elif self.max_score:
-                    all_paper_aff = train_paper_aff_j.max(dim=1)[0]
-                for j in range(paper_num_test):
-                    csv_line = '{note_id},{reviewer},{score}'.format(note_id=test_id_list[j], reviewer=reviewer_id,
-                                                                    score=round(all_paper_aff[j].item(), 4))
-                    csv_scores.append(csv_line)
-                    self.preliminary_scores.append((test_id_list[j], reviewer_id, round(all_paper_aff[j].item(), 4)))
+                    neg_inf_scores = scores.masked_fill(~mask.unsqueeze(0), float('-inf'))
+                    all_paper_aff = neg_inf_scores.max(dim=2).values
+
+                rounded = all_paper_aff.round(decimals=4)
+                for r, reviewer_id in enumerate(reviewer_ids):
+                    for j in range(paper_num_test):
+                        score = rounded[j, r].item()
+                        csv_scores.append(f'{test_id_list[j]},{reviewer_id},{score}')
+                        self.preliminary_scores.append((test_id_list[j], reviewer_id, score))
         print(f"Computed preliminary scores for SciNCL.", flush=True)
 
         if scores_path:

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -322,9 +322,9 @@ class SciNCLPredictor(Predictor):
             if reviewer_ids:
                 max_papers = max(len(papers) for papers in reviewer_paper_indices)
                 num_reviewers = len(reviewer_ids)
-                # reviewer_paper_indices is a ragged Python list (reviewers have
-                # different numbers of papers), so we pad it into a dense matrix.
-                # No PyTorch compute here — just list-to-tensor formatting.
+                # reviewer_paper_indices holds lists of different lengths
+                # (one per reviewer). We pad them into a dense matrix so we
+                # can index all reviewers at once.
                 paper_idx = torch.zeros((num_reviewers, max_papers), dtype=torch.long)
                 mask = torch.zeros((num_reviewers, max_papers), dtype=torch.bool)
                 for r, papers in enumerate(reviewer_paper_indices):

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -301,6 +301,10 @@ class SciNCLPredictor(Predictor):
             self.test_id_list = test_id_list
             self.reviewer_ids = train_id_list
         else:
+            # Build a flat list of valid paper indices per reviewer.
+            # This loop does NOT do any PyTorch compute; it only prepares the
+            # index data so we can run a single bulk gather and reduction
+            # outside the loop (instead of slicing and reducing per reviewer).
             reviewer_ids = []
             reviewer_paper_indices = []
             for reviewer_id, train_note_id_list in self.pub_author_ids_to_note_id.items():
@@ -318,20 +322,32 @@ class SciNCLPredictor(Predictor):
             if reviewer_ids:
                 max_papers = max(len(papers) for papers in reviewer_paper_indices)
                 num_reviewers = len(reviewer_ids)
+                # reviewer_paper_indices is a ragged Python list (reviewers have
+                # different numbers of papers), so we pad it into a dense matrix.
+                # No PyTorch compute here — just list-to-tensor formatting.
                 paper_idx = torch.zeros((num_reviewers, max_papers), dtype=torch.long)
                 mask = torch.zeros((num_reviewers, max_papers), dtype=torch.bool)
                 for r, papers in enumerate(reviewer_paper_indices):
                     paper_idx[r, :len(papers)] = torch.tensor(papers, dtype=torch.long)
                     mask[r, :len(papers)] = True
 
+                # Single bulk gather: all reviewer–paper scores at once.
+                # Old code did p2p_aff_norm[:, train_paper_idx] once per reviewer
+                # inside the loop above; now we do it once for everyone.
                 scores = p2p_aff_norm[:, paper_idx]  # (num_test, num_reviewers, max_papers)
 
+                # Apply venue weights in bulk across the entire 3D tensor.
+                # Old code did this per reviewer inside the loop above.
                 if self.venue_specific_weights:
                     weights = train_weight_tensor[paper_idx]
                     epsilon = 1e-8
                     logits = torch.logit(scores, eps=epsilon)
                     log_w = torch.log(torch.clamp(weights, min=epsilon))
                     scores = torch.sigmoid(logits + log_w.unsqueeze(0))
+
+                # Single bulk reduction across dim=2 (the paper dimension).
+                # Old code did .mean(dim=1), .max(dim=1)[0], or torch.quantile(..., dim=1)
+                # once per reviewer inside the loop above.
 
                 if self.percentile_select is not None:
                     q = max(0.0, min(1.0, self.percentile_select / 100.0))

--- a/expertise/models/specter2_scincl/scincl.py
+++ b/expertise/models/specter2_scincl/scincl.py
@@ -334,7 +334,10 @@ class SciNCLPredictor(Predictor):
                 # Single bulk gather: all reviewer–paper scores at once.
                 # Old code did p2p_aff_norm[:, train_paper_idx] once per reviewer
                 # inside the loop above; now we do it once for everyone.
+                print(f"[SCINCL] num_test={paper_num_test}, num_reviewers={num_reviewers}, max_papers={max_papers}", flush=True)
+                print(f"[SCINCL] paper_idx shape: {paper_idx.shape}, estimated gather size: {paper_num_test * num_reviewers * max_papers * 4 / 1024**3:.2f} GB", flush=True)
                 scores = p2p_aff_norm[:, paper_idx]  # (num_test, num_reviewers, max_papers)
+                print(f"[SCINCL] scores shape after gather: {scores.shape}", flush=True)
 
                 # Apply venue weights in bulk across the entire 3D tensor.
                 # Old code did this per reviewer inside the loop above.

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -314,6 +314,10 @@ class Specter2Predictor(Predictor):
             self.test_id_list = test_id_list
             self.reviewer_ids = train_id_list
         else:
+            # Build a flat list of valid paper indices per reviewer.
+            # This loop does NOT do any PyTorch compute; it only prepares the
+            # index data so we can run a single bulk gather and reduction
+            # outside the loop (instead of slicing and reducing per reviewer).
             reviewer_ids = []
             reviewer_paper_indices = []
             for reviewer_id, train_note_id_list in self.pub_author_ids_to_note_id.items():
@@ -331,20 +335,32 @@ class Specter2Predictor(Predictor):
             if reviewer_ids:
                 max_papers = max(len(papers) for papers in reviewer_paper_indices)
                 num_reviewers = len(reviewer_ids)
+                # reviewer_paper_indices is a ragged Python list (reviewers have
+                # different numbers of papers), so we pad it into a dense matrix.
+                # No PyTorch compute here — just list-to-tensor formatting.
                 paper_idx = torch.zeros((num_reviewers, max_papers), dtype=torch.long)
                 mask = torch.zeros((num_reviewers, max_papers), dtype=torch.bool)
                 for r, papers in enumerate(reviewer_paper_indices):
                     paper_idx[r, :len(papers)] = torch.tensor(papers, dtype=torch.long)
                     mask[r, :len(papers)] = True
 
+                # Single bulk gather: all reviewer–paper scores at once.
+                # Old code did p2p_aff_norm[:, train_paper_idx] once per reviewer
+                # inside the loop above; now we do it once for everyone.
                 scores = p2p_aff_norm[:, paper_idx]  # (num_test, num_reviewers, max_papers)
 
+                # Apply venue weights in bulk across the entire 3D tensor.
+                # Old code did this per reviewer inside the loop above.
                 if self.venue_specific_weights:
                     weights = train_weight_tensor[paper_idx]
                     epsilon = 1e-8
                     logits = torch.logit(scores, eps=epsilon)
                     log_w = torch.log(torch.clamp(weights, min=epsilon))
                     scores = torch.sigmoid(logits + log_w.unsqueeze(0))
+
+                # Single bulk reduction across dim=2 (the paper dimension).
+                # Old code did .mean(dim=1), .max(dim=1)[0], or torch.quantile(..., dim=1)
+                # once per reviewer inside the loop above.
 
                 if self.percentile_select is not None:
                     q = max(0.0, min(1.0, self.percentile_select / 100.0))

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -335,9 +335,9 @@ class Specter2Predictor(Predictor):
             if reviewer_ids:
                 max_papers = max(len(papers) for papers in reviewer_paper_indices)
                 num_reviewers = len(reviewer_ids)
-                # reviewer_paper_indices is a ragged Python list (reviewers have
-                # different numbers of papers), so we pad it into a dense matrix.
-                # No PyTorch compute here — just list-to-tensor formatting.
+                # reviewer_paper_indices holds lists of different lengths
+                # (one per reviewer). We pad them into a dense matrix so we
+                # can index all reviewers at once.
                 paper_idx = torch.zeros((num_reviewers, max_papers), dtype=torch.long)
                 mask = torch.zeros((num_reviewers, max_papers), dtype=torch.bool)
                 for r, papers in enumerate(reviewer_paper_indices):

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -314,41 +314,53 @@ class Specter2Predictor(Predictor):
                     csv_scores.append(csv_line)
                     self.preliminary_scores.append((test_id_list[j], train_id_list[i], round(p2p_aff_norm[j, i].item(), 4)))
         else:
+            reviewer_ids = []
+            reviewer_paper_indices = []
             for reviewer_id, train_note_id_list in self.pub_author_ids_to_note_id.items():
                 if len(train_note_id_list) == 0:
                     continue
-                train_paper_idx = []
-                for paper_id in train_note_id_list:
-                    if paper_id not in train_bad_id_set:
-                        train_paper_idx.append(paper_id2train_idx[paper_id])
-                train_paper_aff_j = p2p_aff_norm[:, train_paper_idx]
+                valid = [paper_id2train_idx[pid] for pid in train_note_id_list if pid not in train_bad_id_set]
+                if not valid:
+                    continue
+                reviewer_ids.append(reviewer_id)
+                reviewer_paper_indices.append(valid)
 
-                # Apply venue-specific weights per reviewer
+            if reviewer_ids:
+                max_papers = max(len(papers) for papers in reviewer_paper_indices)
+                num_reviewers = len(reviewer_ids)
+                paper_idx = torch.zeros((num_reviewers, max_papers), dtype=torch.long)
+                mask = torch.zeros((num_reviewers, max_papers), dtype=torch.bool)
+                for r, papers in enumerate(reviewer_paper_indices):
+                    paper_idx[r, :len(papers)] = torch.tensor(papers, dtype=torch.long)
+                    mask[r, :len(papers)] = True
+
+                scores = p2p_aff_norm[:, paper_idx]  # (num_test, num_reviewers, max_papers)
+
                 if self.venue_specific_weights:
-                    train_weight_j = train_weight_tensor[train_paper_idx]
-                    # Logit-space transformation preserves bounds and probability mass
-                    epsilon = 1e-8 ## Numerical stability
-                    logits = torch.logit(train_paper_aff_j, eps=epsilon)
-                    weighted_logits = logits + torch.log(torch.clamp(train_weight_j, min=epsilon)).unsqueeze(0)
-                    train_paper_aff_j = torch.sigmoid(weighted_logits)
+                    weights = train_weight_tensor[paper_idx]
+                    epsilon = 1e-8
+                    logits = torch.logit(scores, eps=epsilon)
+                    log_w = torch.log(torch.clamp(weights, min=epsilon))
+                    scores = torch.sigmoid(logits + log_w.unsqueeze(0))
 
                 if self.percentile_select is not None:
-                    # Select score based on percentile
-                    # q=1.0 (percentile_select=100) -> max score
-                    # q=0.5 (percentile_select=50) -> median score
-                    # q=0.0 (percentile_select=0) -> min score
-                    q = self.percentile_select / 100.0
-                    q = max(0.0, min(1.0, q))
-                    all_paper_aff = torch.quantile(train_paper_aff_j, q, dim=1, interpolation='linear')
+                    q = max(0.0, min(1.0, self.percentile_select / 100.0))
+                    nan_scores = scores.masked_fill(~mask.unsqueeze(0), float('nan'))
+                    all_paper_aff = torch.nanquantile(nan_scores, q, dim=2, interpolation='linear')
                 elif self.average_score:
-                    all_paper_aff = train_paper_aff_j.mean(dim=1)
+                    zero_scores = scores.masked_fill(~mask.unsqueeze(0), 0.0)
+                    counts = mask.sum(dim=1).clamp(min=1).to(scores.dtype)
+                    all_paper_aff = zero_scores.sum(dim=2) / counts.unsqueeze(0)
                 elif self.max_score:
-                    all_paper_aff = train_paper_aff_j.max(dim=1)[0]
-                for j in range(paper_num_test):
-                    csv_line = '{note_id},{reviewer},{score}'.format(note_id=test_id_list[j], reviewer=reviewer_id,
-                                                                    score=round(all_paper_aff[j].item(), 4))
-                    csv_scores.append(csv_line)
-                    self.preliminary_scores.append((test_id_list[j], reviewer_id, round(all_paper_aff[j].item(), 4)))
+                    neg_inf_scores = scores.masked_fill(~mask.unsqueeze(0), float('-inf'))
+                    all_paper_aff = neg_inf_scores.max(dim=2).values
+
+                rounded = all_paper_aff.round(decimals=4)
+                for r, reviewer_id in enumerate(reviewer_ids):
+                    for j in range(paper_num_test):
+                        score = rounded[j, r].item()
+                        csv_scores.append(f'{test_id_list[j]},{reviewer_id},{score}')
+                        self.preliminary_scores.append((test_id_list[j], reviewer_id, score))
         print(f"Computed preliminary scores for SPECTER2.", flush=True)
 
         if scores_path:

--- a/expertise/models/specter2_scincl/specter.py
+++ b/expertise/models/specter2_scincl/specter.py
@@ -347,7 +347,10 @@ class Specter2Predictor(Predictor):
                 # Single bulk gather: all reviewer–paper scores at once.
                 # Old code did p2p_aff_norm[:, train_paper_idx] once per reviewer
                 # inside the loop above; now we do it once for everyone.
+                print(f"[SPECTER] num_test={paper_num_test}, num_reviewers={num_reviewers}, max_papers={max_papers}", flush=True)
+                print(f"[SPECTER] paper_idx shape: {paper_idx.shape}, estimated gather size: {paper_num_test * num_reviewers * max_papers * 4 / 1024**3:.2f} GB", flush=True)
                 scores = p2p_aff_norm[:, paper_idx]  # (num_test, num_reviewers, max_papers)
+                print(f"[SPECTER] scores shape after gather: {scores.shape}", flush=True)
 
                 # Apply venue weights in bulk across the entire 3D tensor.
                 # Old code did this per reviewer inside the loop above.


### PR DESCRIPTION
Closes #385.

Replaces the per-reviewer tensor slicing and reduction loop with a single bulk gather across all reviewers followed by a vectorized dim=2 reduction. 

Old code iterated reviewers one by one, with each iteration running a nested paper loop to build `train_paper_idx`, slicing `p2p_aff_norm[:, train_paper_idx]`, optionally weighting that 2D slice in logit space, reducing via `torch.quantile(..., dim=1)` or `.mean(dim=1)` or `.max(dim=1)[0]`, and appending to `score_vectors` for a final `torch.stack(..., dim=1)`. 

New code keeps the outer loop but strips it to just collecting valid paper indices via list comprehension. After the loop, a padding pass fills a dense `(num_reviewers, max_papers)` `paper_idx` tensor and boolean mask. 

Then `p2p_aff_norm[:, paper_idx]` gathers all reviewer-paper scores in one shot into `(num_test, num_reviewers, max_papers)`. 
Venue weights use `train_weight_tensor[paper_idx]` on the full 3D tensor. A single reduction across `dim=2` produces the final matrix: percentile via `torch.nanquantile` with NaN masking, average via zero-masked sum divided by counts, max via -inf masking. The PyTorch ops moved from once per reviewer inside the loop to once total outside the loop. Remaining loops only do Python list manipulation and tensor padding. Same change in specter.py and scincl.py. 