### PR TITLE
New `/expertise/metadata` endpoint

### DIFF
--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -770,6 +770,28 @@ class ExpertiseService(BaseExpertiseService):
 
         return result
 
+    def get_expertise_metadata(self, user_id, job_id):
+        """
+        Gets the dataset metadata for a given job (submission/archive counts,
+        missing profiles and publications). Lighter than get_expertise_results
+        since it doesn't read the score file.
+        """
+        config = self.redis.load_job(job_id, user_id)
+
+        if config.status != JobStatus.COMPLETED:
+            raise openreview.OpenReviewException(
+                f"Metadata not available - status: {config.status} | description: {config.description}"
+            )
+
+        metadata_path = os.path.join(config.job_dir, 'metadata.json')
+        if not os.path.isfile(metadata_path):
+            raise openreview.OpenReviewException(
+                f"Metadata file not found for job {job_id}"
+            )
+
+        with open(metadata_path, 'r') as f:
+            return json.load(f)
+
 class ExpertiseCloudService(BaseExpertiseService):
 
     def __init__(self, config, logger, containerized = False):
@@ -1100,3 +1122,15 @@ class ExpertiseCloudService(BaseExpertiseService):
         """
         redis_job = self.redis.load_job(job_id, user_id)
         return self.cloud.get_job_results(user_id, redis_job.cloud_id, delete_on_get)
+
+    def get_expertise_metadata(self, user_id, job_id):
+        """
+        Gets the dataset metadata for a given job (submission/archive counts,
+        missing profiles and publications) by reading metadata.json from GCS.
+        """
+        redis_job = self.redis.load_job(job_id, user_id)
+        if redis_job.status != JobStatus.COMPLETED:
+            raise openreview.OpenReviewException(
+                f"Metadata not available - status: {redis_job.status} | description: {redis_job.description}"
+            )
+        return self.cloud.get_job_metadata(user_id, redis_job.cloud_id)

--- a/expertise/service/routes.py
+++ b/expertise/service/routes.py
@@ -372,6 +372,52 @@ def results():
         flask.current_app.logger.error(str(error_handle), exc_info=True)
         return flask.jsonify(format_error(500, 'Internal server error: {}'.format(error_handle))), 500
 
+@BLUEPRINT.route('/expertise/metadata', methods=['GET'])
+@require_auth
+def metadata():
+    """
+    Get the dataset metadata of a single submitted job. Intended for venue
+    organizers who want to surface missing profiles and publications without
+    pulling the full score file (which can now be retrieved as CSV via
+    /expertise/results?format=csv).
+
+    :param token: Authorization from a logged in user, which defines the set of accessible data
+    :type token: str
+
+    :param jobId: The ID of a submitted job
+    :type jobId: str
+    """
+    try:
+        user_id = g.user_id
+        flask.current_app.logger.debug('GET receives ' + str(flask.request.args))
+        job_id = flask.request.args.get('jobId', None)
+        if job_id is None or len(job_id) == 0:
+            raise openreview.OpenReviewException('Bad request: jobId is required')
+
+        expertise_service = get_expertise_service(flask.current_app.config, flask.current_app.logger)
+        result = expertise_service.get_expertise_metadata(user_id, job_id)
+        return flask.jsonify(result), 200
+
+    except openreview.OpenReviewException as error_handle:
+        flask.current_app.logger.error(str(error_handle), exc_info=True)
+
+        error_type = str(error_handle)
+        status = 500
+
+        if 'not found' in error_type.lower():
+            status = 404
+        elif 'forbidden' in error_type.lower():
+            status = 403
+        elif 'bad request' in error_type.lower():
+            status = 400
+
+        return flask.jsonify(format_error(status, error_type)), status
+
+    # pylint:disable=broad-except
+    except Exception as error_handle:
+        flask.current_app.logger.error(str(error_handle), exc_info=True)
+        return flask.jsonify(format_error(500, 'Internal server error: {}'.format(error_handle))), 500
+
 @BLUEPRINT.route('/startup')
 def startup():
     """An endpoint for checking availability for predictions"""

--- a/expertise/service/utils.py
+++ b/expertise/service/utils.py
@@ -1589,3 +1589,35 @@ class GCPInterface(object):
 
         return _get_scores_and_metadata_streaming(job_blobs, job_id, group_group_matching, paper_paper_matching)
 
+    def get_job_metadata(self, user_id, job_id):
+        """
+        Returns the dataset metadata dict for a job (submission/archive counts,
+        missing profiles and publications). Excludes the metadata.json packed
+        inside dataset/ — that one is part of the input artifact, not the
+        post-pipeline output.
+        """
+        job_blobs = list(self.bucket.list_blobs(prefix=f"{self.jobs_folder}/{job_id}/"))
+        self.logger.info(f"Searching for job {job_id} metadata | prefix={self.jobs_folder}/{job_id}/")
+        all_requests = [
+            json.loads(blob.download_as_string()) for blob in job_blobs if self.request_fname in blob.name
+        ]
+        authenticated_requests = [
+            req for req in all_requests if user_id == req['user_id'] or user_id in SUPERUSER_IDS
+        ]
+        if len(all_requests) == 0:
+            raise openreview.OpenReviewException('Job not found')
+        if len(authenticated_requests) == 0:
+            raise openreview.OpenReviewException('Forbidden: Insufficient permissions to access job')
+        if len(authenticated_requests) > 1:
+            raise openreview.OpenReviewException('Internal Error: Multiple requests found for job')
+
+        metadata_files = [
+            blob for blob in job_blobs if 'metadata.json' in blob.name and 'dataset/' not in blob.name
+        ]
+        if len(metadata_files) != 1:
+            raise openreview.OpenReviewException(
+                f'Internal Error: incorrect metadata files found expected [1] found {len(metadata_files)}'
+            )
+
+        return json.loads(metadata_files[0].download_as_string())
+

--- a/tests/test_expertise_cloud_service.py
+++ b/tests/test_expertise_cloud_service.py
@@ -461,6 +461,17 @@ class TestExpertiseCloudService():
             {"entityB": "abcde","entityA": "user_user2","score": 0.987}
         ]
 
+        # /expertise/metadata returns the same metadata document directly
+        # (no score file read), so venue organizers can list missing
+        # profiles/publications without pulling the full result set.
+        metadata_response = test_client.get(
+            '/expertise/metadata',
+            headers=tmlr_client.headers,
+            query_string={'jobId': job_id},
+        )
+        assert metadata_response.status_code == 200
+        assert metadata_response.json == {"meta": "data"}
+
     @patch("expertise.service.utils.aip.PipelineJob")  # Mock PipelineJob to avoid calling AI Platform
     def test_group_group_scores(self, mock_pipeline_job, openreview_client, openreview_context_cloud, gcs_test_bucket, gcs_jobs_prefix):
         def setup_job_mocks():

--- a/tests/test_expertise_service.py
+++ b/tests/test_expertise_service.py
@@ -968,6 +968,39 @@ class TestExpertiseService():
         assert "~C.V._Lastname1" in all_users
 
 
+    def test_get_metadata_by_job_id(self, openreview_client, openreview_context):
+        test_client = openreview_context['test_client']
+        response = test_client.get(
+            '/expertise/metadata',
+            headers=openreview_client.headers,
+            query_string={'jobId': f"{openreview_context['job_id']}"},
+        )
+        assert response.status_code == 200
+        metadata = response.json
+        assert metadata['submission_count'] == 2
+        assert metadata['archives_count'] == 10
+        # Lists of missing profiles / publications must be present even when empty
+        # so venue-organizer UIs can render the section without null checks.
+        assert isinstance(metadata.get('no_profile', []), list)
+        assert isinstance(metadata.get('no_publications', []), list)
+
+    def test_get_metadata_for_unknown_job(self, openreview_client, openreview_context):
+        test_client = openreview_context['test_client']
+        response = test_client.get(
+            '/expertise/metadata',
+            headers=openreview_client.headers,
+            query_string={'jobId': 'nonexistent_job_id'},
+        )
+        assert response.status_code == 404
+
+    def test_get_metadata_without_job_id(self, openreview_client, openreview_context):
+        test_client = openreview_context['test_client']
+        response = test_client.get(
+            '/expertise/metadata',
+            headers=openreview_client.headers,
+        )
+        assert response.status_code == 400
+
     def test_compare_results_for_identical_jobs(self, openreview_client, openreview_context):
         test_client = openreview_context['test_client']
         # Searches for results from the given job_id assuming the job has completed


### PR DESCRIPTION
## Summary

Adds `GET /expertise/metadata?jobId=<id>`, which returns the dataset metadata for a completed job: submission/archive counts plus the lists of profiles and publications that couldn't be matched (`no_profile`, `no_publications`, `no_profile_submission`).

The previous PR added `?format=csv` to `/expertise/results` to skip JSON parsing for large jobs. CSV has no place for the metadata envelope, so clients that switch to CSV currently lose access to the "missing" lists that venue organizers need to surface in the UI.

## Why a separate endpoint

Mixing a `format=metadata` mode into `/expertise/results` would make the "results" route return no results. A dedicated route is one blob read, self-documenting, and can be called independently of how scores are fetched. The response is the raw `metadata.json` dict — no curated projection, so anything `execute_create_dataset` writes shows up automatically.

## API

`GET /expertise/metadata?jobId=X` → `application/json`:

```json
{
  "submission_count": 2,
  "archives_count": 10,
  "no_profile": [...],
  "no_publications": [...],
  "no_publications_count": 0,
  "no_profile_submission": [...]
}
```

Same auth (`require_auth`) and error mapping as the other routes (400 / 403 / 404 / 500). Requires job status `Completed`.

## Changes

- [`service/expertise.py`](expertise/service/expertise.py) — `ExpertiseService.get_expertise_metadata` reads `metadata.json` from `config.job_dir`; `ExpertiseCloudService.get_expertise_metadata` validates status and delegates to the GCP interface.
- [`service/utils.py`](expertise/service/utils.py) — `GCPInterface.get_job_metadata` mirrors the auth pattern in `get_job_results`, then downloads the top-level `metadata.json` blob (excluding the one packed inside `dataset/`, which is the input artifact).
- [`service/routes.py`](expertise/service/routes.py) — new blueprint route, standard try/except error mapping.

## Tests

- `tests/test_expertise_service.py` — three new tests: happy path (asserts counts + that the missing lists are present), unknown job (404), missing `jobId` (400).
- `tests/test_expertise_cloud_service.py::test_journal_results` — extended to also hit `/expertise/metadata` and assert it returns the metadata blob uploaded to the test GCS bucket.

## Migration notes

No changes to existing routes. `/expertise/results` still returns the same JSON envelope by default — clients on `?format=csv` should make a parallel call to `/expertise/metadata` for the missing-profile / missing-publication lists.
