### PR TITLE
baseline tests for reviewer score aggregation correctness

### DIFF
--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -814,3 +814,233 @@ def test_all_scores_skips_reviewer_with_only_bad_embeddings(tmp_path):
     # Score is finite (no NaN from a degenerate reduction).
     score = model.scores_matrix[0, 0].item()
     assert score == score, "Score must not be NaN"
+
+
+@pytest.mark.parametrize("aggregation_mode,use_weights", [
+    ("max", False),
+    ("average", False),
+    ("percentile", False),
+    ("max", True),
+    ("average", True),
+    ("percentile", True),
+])
+def test_vectorized_aggregation_matches_reference_loop(tmp_path, aggregation_mode, use_weights):
+    """Regression for PR #386: verify vectorized reviewer aggregation produces
+    the same scores as the pre-change loop-based implementation.
+
+    Uses hand-crafted embeddings so p2p_aff values are deterministic.
+    Reviewers have varying paper counts (tests padding/masking).
+    One paper has a zero-length embedding (tests bad_id filtering).
+    """
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    predictor = specter2_scincl.Specter2Predictor(
+        specter_dir="../expertise-utils/specter/",
+        work_dir=str(work_dir),
+        use_cuda=False,
+        normalize_scores=False,
+        average_score=(aggregation_mode == "average"),
+        max_score=(aggregation_mode == "max"),
+        percentile_select=83 if aggregation_mode == "percentile" else None,
+        venue_specific_weights=use_weights,
+    )
+
+    # --- 1. Archives: 3 reviewers with varying paper counts ---
+    archive_dir = tmp_path / "archives"
+    archive_dir.mkdir()
+    # Rev1: 2 papers
+    (archive_dir / "~Rev1.jsonl").write_text(
+        json.dumps({"id": "p1", "content": {"title": "P1", "abstract": "A1"}}) + "\n"
+        + json.dumps({"id": "p2", "content": {"title": "P2", "abstract": "A2"}}) + "\n"
+    )
+    # Rev2: 3 papers (one will have bad embedding)
+    (archive_dir / "~Rev2.jsonl").write_text(
+        json.dumps({"id": "p2", "content": {"title": "P2", "abstract": "A2"}}) + "\n"
+        + json.dumps({"id": "p3", "content": {"title": "P3", "abstract": "A3"}}) + "\n"
+        + json.dumps({"id": "p4", "content": {"title": "P4", "abstract": "A4"}}) + "\n"
+    )
+    # Rev3: 1 paper
+    (archive_dir / "~Rev3.jsonl").write_text(
+        json.dumps({"id": "p5", "content": {"title": "P5", "abstract": "A5"}}) + "\n"
+    )
+
+    archives_dataset = ArchivesDataset(archives_path=archive_dir)
+    predictor.set_archives_dataset(archives_dataset)
+
+    # --- 2. Submissions: 2 submissions ---
+    sub_dir = tmp_path / "submissions"
+    sub_dir.mkdir()
+    (sub_dir / "Sub1.jsonl").write_text(
+        json.dumps({"id": "Sub1", "content": {"title": "S1", "abstract": "S1"}}) + "\n"
+    )
+    (sub_dir / "Sub2.jsonl").write_text(
+        json.dumps({"id": "Sub2", "content": {"title": "S2", "abstract": "S2"}}) + "\n"
+    )
+
+    submissions_dataset = SubmissionsDataset(submissions_path=sub_dir)
+    predictor.set_submissions_dataset(submissions_dataset)
+
+    # --- 3. Hand-crafted embeddings ---
+    # Use 768-dim vectors where unit vectors produce predictable dot products.
+    # After load_emb_file normalization, e_i stays e_i (already unit length).
+    def unit_vec(i):
+        v = [0.0] * 768
+        v[i] = 1.0
+        return v
+
+    # Publications:
+    #   p1 = e0, p2 = e1, p3 = e2, p4 = e3, p5 = e4
+    # Submissions:
+    #   Sub1 = (e0 + e1) / sqrt(2)
+    #   Sub2 = (e1 + e2) / sqrt(2)
+    #
+    # Expected raw p2p_aff (before normalization, which is disabled):
+    #           p1    p2    p3    p4    p5
+    #   Sub1  1/√2  1/√2   0     0     0
+    #   Sub2   0    1/√2  1/√2   0     0
+    #
+    # p4 has a zero-length embedding -> added to train_bad_id_set.
+    # So Rev2 effectively has papers [p2, p3] after filtering.
+
+    pub_lines = (
+        json.dumps({"paper_id": "p1", "embedding": unit_vec(0)}) + "\n"
+        + json.dumps({"paper_id": "p2", "embedding": unit_vec(1)}) + "\n"
+        + json.dumps({"paper_id": "p3", "embedding": unit_vec(2)}) + "\n"
+        + json.dumps({"paper_id": "p4", "embedding": []}) + "\n"  # bad embedding
+        + json.dumps({"paper_id": "p5", "embedding": unit_vec(4)}) + "\n"
+    )
+
+    def sub_vec(i, j):
+        v = [0.0] * 768
+        v[i] = 1.0 / (2 ** 0.5)
+        v[j] = 1.0 / (2 ** 0.5)
+        return v
+
+    sub_lines = (
+        json.dumps({"paper_id": "Sub1", "embedding": sub_vec(0, 1)}) + "\n"
+        + json.dumps({"paper_id": "Sub2", "embedding": sub_vec(1, 2)}) + "\n"
+    )
+
+    pub_path = work_dir / "pub2vec_specter.jsonl"
+    sub_path = work_dir / "sub2vec_specter.jsonl"
+    pub_path.write_text(pub_lines)
+    sub_path.write_text(sub_lines)
+
+    # --- 4. Venue weights metadata (if needed) ---
+    if use_weights:
+        weights_meta = {
+            "p1": {"weight": 2.0},
+            "p2": {"weight": 1.0},
+            "p3": {"weight": 0.5},
+            "p4": {"weight": 1.0},
+            "p5": {"weight": 3.0},
+        }
+        with open(work_dir / "specter_reviewer_paper_data.json", "w") as f:
+            json.dump(weights_meta, f)
+
+    # --- 5. Run the vectorized code ---
+    predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
+
+    # --- 6. Compute reference scores with the old loop ---
+    # Load embeddings to reconstruct p2p_aff
+    with open(pub_path) as f:
+        pub_embs = {}
+        for line in f:
+            d = json.loads(line)
+            if d["embedding"]:
+                e = torch.tensor(d["embedding"], dtype=torch.float32)
+                e = e / (e.norm() + 1e-12)
+                pub_embs[d["paper_id"]] = e
+
+    with open(sub_path) as f:
+        sub_embs = {}
+        for line in f:
+            d = json.loads(line)
+            e = torch.tensor(d["embedding"], dtype=torch.float32)
+            e = e / (e.norm() + 1e-12)
+            sub_embs[d["paper_id"]] = e
+
+    sub_ids = ["Sub1", "Sub2"]
+    pub_ids = ["p1", "p2", "p3", "p4", "p5"]
+    p2p = torch.zeros((2, 5), dtype=torch.float32)
+    for i, sid in enumerate(sub_ids):
+        for j, pid in enumerate(pub_ids):
+            if pid in pub_embs:
+                p2p[i, j] = sub_embs[sid].dot(pub_embs[pid]).item()
+
+    # Reviewer paper indices after bad_id filtering
+    reviewer_papers = {
+        "~Rev1": ["p1", "p2"],
+        "~Rev2": ["p2", "p3"],  # p4 filtered out
+        "~Rev3": ["p5"],
+    }
+    pub_id_to_idx = {pid: j for j, pid in enumerate(pub_ids)}
+
+    # Load weights if needed
+    weights = None
+    if use_weights:
+        with open(work_dir / "specter_reviewer_paper_data.json") as f:
+            weights_meta = json.load(f)
+        weights = torch.tensor([weights_meta.get(pid, {}).get("weight", 1.0) for pid in pub_ids], dtype=torch.float32)
+
+    ref_vectors = []
+    ref_reviewer_ids = []
+    for rev_id, papers in reviewer_papers.items():
+        paper_indices = [pub_id_to_idx[p] for p in papers]
+        train_paper_aff_j = p2p[:, paper_indices]
+
+        if use_weights:
+            train_weight_j = weights[paper_indices]
+            epsilon = 1e-8
+            logits = torch.logit(train_paper_aff_j.clamp(epsilon, 1 - epsilon), eps=epsilon)
+            log_w = torch.log(torch.clamp(train_weight_j, min=epsilon))
+            weighted_logits = logits + log_w.unsqueeze(0)
+            train_paper_aff_j = torch.sigmoid(weighted_logits)
+
+        if aggregation_mode == "percentile":
+            q = 0.83
+            all_paper_aff = torch.quantile(train_paper_aff_j, q, dim=1, interpolation='linear')
+        elif aggregation_mode == "average":
+            all_paper_aff = train_paper_aff_j.mean(dim=1)
+        elif aggregation_mode == "max":
+            all_paper_aff = train_paper_aff_j.max(dim=1)[0]
+
+        ref_vectors.append(all_paper_aff)
+        ref_reviewer_ids.append(rev_id)
+
+    ref_matrix = torch.stack(ref_vectors, dim=1)  # [2, 3]
+
+    # --- 7. Compare using the same dict-based pattern as compare_scores.py ---
+    actual_scores = {}
+    for i, sub_id in enumerate(predictor.test_id_list):
+        for j, rev_id in enumerate(predictor.reviewer_ids):
+            actual_scores[(sub_id, rev_id)] = round(float(predictor.scores_matrix[i, j]), 4)
+
+    ref_scores = {}
+    for i, sub_id in enumerate(sub_ids):
+        for j, rev_id in enumerate(ref_reviewer_ids):
+            ref_scores[(sub_id, rev_id)] = round(float(ref_matrix[i, j]), 4)
+
+    common = set(actual_scores.keys()) & set(ref_scores.keys())
+    diffs = []
+    for key in common:
+        if actual_scores[key] != ref_scores[key]:
+            diffs.append({
+                "submission_id": key[0],
+                "reviewer_id": key[1],
+                "score_actual": actual_scores[key],
+                "score_expected": ref_scores[key],
+                "delta": actual_scores[key] - ref_scores[key],
+            })
+
+    assert len(diffs) == 0, (
+        f"Score mismatch in mode={aggregation_mode}, weights={use_weights}: "
+        f"{len(diffs)} pairs differ out of {len(common)} total.\n"
+        + "\n".join(
+            f"  {d['submission_id']} / {d['reviewer_id']}: "
+            f"actual={d['score_actual']:.4f} expected={d['score_expected']:.4f} "
+            f"delta={d['delta']:+.4f}"
+            for d in diffs[:10]
+        )
+    )

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -985,7 +985,7 @@ def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
         use_cuda=False,
         normalize_scores=False,
         average_score=False,
-        max_score=False,
+        max_score=True,
         percentile_select=50,
     )
     predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -822,6 +822,29 @@ def _pad_to_768(emb):
     return emb + [0.0] * (768 - len(emb))
 
 
+def _make_predictor(tmp_path, **kwargs):
+    """Construct a Specter2Predictor with HF model loading mocked out.
+
+    These aggregation tests only exercise all_scores() with precomputed
+    embeddings, so the tokenizer/model load is unnecessary and would slow
+    down or flake CI.
+    """
+    with patch("expertise.models.specter2_scincl.specter.AutoTokenizer.from_pretrained") as mock_tok, \
+         patch("expertise.models.specter2_scincl.specter.AutoAdapterModel.from_pretrained") as mock_model:
+        mock_tok.return_value = MagicMock()
+        mock_model.return_value = MagicMock()
+        mock_model.return_value.load_adapter = MagicMock()
+        mock_model.return_value.to = MagicMock(return_value=mock_model.return_value)
+        mock_model.return_value.eval = MagicMock(return_value=mock_model.return_value)
+        return specter2_scincl.Specter2Predictor(
+            specter_dir="../expertise-utils/specter/",
+            work_dir=str(tmp_path),
+            use_cuda=False,
+            normalize_scores=False,
+            **kwargs
+        )
+
+
 def test_reviewer_aggregation_max_matches_manual_loop(tmp_path):
     """The vectorized max-score aggregation must match a plain Python loop.
 
@@ -847,11 +870,8 @@ def test_reviewer_aggregation_max_matches_manual_loop(tmp_path):
         json.dumps({"id": "Sub1", "content": {"title": "S", "abstract": "s"}}) + "\n"
     )
 
-    predictor = specter2_scincl.Specter2Predictor(
-        specter_dir="../expertise-utils/specter/",
-        work_dir=str(tmp_path),
-        use_cuda=False,
-        normalize_scores=False,
+    predictor = _make_predictor(
+        tmp_path,
         average_score=False,
         max_score=True,
     )
@@ -915,11 +935,8 @@ def test_reviewer_aggregation_average_matches_manual_loop(tmp_path):
         json.dumps({"id": "Sub1", "content": {"title": "S", "abstract": "s"}}) + "\n"
     )
 
-    predictor = specter2_scincl.Specter2Predictor(
-        specter_dir="../expertise-utils/specter/",
-        work_dir=str(tmp_path),
-        use_cuda=False,
-        normalize_scores=False,
+    predictor = _make_predictor(
+        tmp_path,
         average_score=True,
         max_score=False,
     )
@@ -983,13 +1000,10 @@ def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
         json.dumps({"id": "Sub1", "content": {"title": "S", "abstract": "s"}}) + "\n"
     )
 
-    predictor = specter2_scincl.Specter2Predictor(
-        specter_dir="../expertise-utils/specter/",
-        work_dir=str(tmp_path),
-        use_cuda=False,
-        normalize_scores=False,
+    predictor = _make_predictor(
+        tmp_path,
         average_score=False,
-        max_score=True,
+        max_score=True,  # required by constructor xor assertion; percentile_select wins in all_scores
         percentile_select=50,
     )
     predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))
@@ -1056,11 +1070,8 @@ def test_reviewer_aggregation_with_weights_preserves_and_flips_ordering(tmp_path
         json.dumps({"id": "Sub1", "content": {"title": "S", "abstract": "s"}}) + "\n"
     )
 
-    predictor = specter2_scincl.Specter2Predictor(
-        specter_dir="../expertise-utils/specter/",
-        work_dir=str(tmp_path),
-        use_cuda=False,
-        normalize_scores=False,
+    predictor = _make_predictor(
+        tmp_path,
         average_score=True,
         max_score=False,
         venue_specific_weights=True,
@@ -1112,8 +1123,8 @@ def test_reviewer_aggregation_with_weights_preserves_and_flips_ordering(tmp_path
 
 
 def test_reviewer_aggregation_skips_bad_embeddings(tmp_path):
-    """A reviewer whose only valid paper gets filtered as a bad embedding
-    must be dropped entirely (0-column matrix, not NaN).
+    """Reviewers whose only paper has a bad (empty) embedding are dropped.
+    The remaining reviewer produces a [1, 1] matrix with a finite score.
     """
     archive_dir = tmp_path / "archives"
     archive_dir.mkdir()
@@ -1130,11 +1141,8 @@ def test_reviewer_aggregation_skips_bad_embeddings(tmp_path):
         json.dumps({"id": "Sub1", "content": {"title": "S", "abstract": "s"}}) + "\n"
     )
 
-    predictor = specter2_scincl.Specter2Predictor(
-        specter_dir="../expertise-utils/specter/",
-        work_dir=str(tmp_path),
-        use_cuda=False,
-        normalize_scores=False,
+    predictor = _make_predictor(
+        tmp_path,
         average_score=True,
         max_score=False,
     )

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -891,6 +891,8 @@ def test_reviewer_aggregation_max_matches_manual_loop(tmp_path):
     rev2_idx = predictor.reviewer_ids.index("~Rev2")
     assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == 0.7000  # Rev1: max(0.3, 0.7)
     assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == 0.5000  # Rev2: max(0.5, 0.2)
+    # Ordering: Rev1 scored higher than Rev2 for Sub1
+    assert predictor.scores_matrix[0, rev1_idx].item() > predictor.scores_matrix[0, rev2_idx].item()
 
 
 def test_reviewer_aggregation_average_matches_manual_loop(tmp_path):
@@ -957,6 +959,8 @@ def test_reviewer_aggregation_average_matches_manual_loop(tmp_path):
     rev2_idx = predictor.reviewer_ids.index("~Rev2")
     assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == round((0.2 + 0.6) / 2, 4)
     assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == round((0.4 + 0.1 + 0.3) / 3, 4)
+    # Ordering: Rev1 scored higher than Rev2 for Sub1
+    assert predictor.scores_matrix[0, rev1_idx].item() > predictor.scores_matrix[0, rev2_idx].item()
 
 
 def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
@@ -1026,18 +1030,24 @@ def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
     assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == 0.4000
     # Rev2 papers [C=0.3, D=0.5, E=0.1] -> median = 0.3
     assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == 0.3000
+    # Ordering: Rev1 scored higher than Rev2 for Sub1
+    assert predictor.scores_matrix[0, rev1_idx].item() > predictor.scores_matrix[0, rev2_idx].item()
 
 
-def test_reviewer_aggregation_with_weights_matches_manual_loop(tmp_path):
-    """Venue-weighted aggregation must match a plain Python loop.
+def test_reviewer_aggregation_with_weights_preserves_and_flips_ordering(tmp_path):
+    """Venue weights must flip reviewer ordering when raw scores differ.
 
-    The weight is applied in logit space: sigmoid(logit(score) + log(weight)).
+    Setup: Rev1 raw score 0.3, Rev2 raw score 0.8  (Rev2 > Rev1 without weights).
+    Weights: Rev1 paper gets 5.0 (boost), Rev2 paper gets 0.1 (penalty).
+    Expected: with weights Rev1 > Rev2 (ordering flips).
     """
     archive_dir = tmp_path / "archives"
     archive_dir.mkdir()
     (archive_dir / "~Rev1.jsonl").write_text(
         json.dumps({"id": "A", "content": {"title": "A", "abstract": "a"}}) + "\n"
-        + json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
+    )
+    (archive_dir / "~Rev2.jsonl").write_text(
+        json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
     )
 
     sub_dir = tmp_path / "submissions"
@@ -1060,8 +1070,8 @@ def test_reviewer_aggregation_with_weights_matches_manual_loop(tmp_path):
 
     emb_a = _pad_to_768([1.0])                         # e0
     emb_b = _pad_to_768([0.0, 1.0])                    # e1
-    # Sub1 = [0.7, 0.5, sqrt(0.26), 0, ...]  (unit length)
-    sub_comps = [0.7, 0.5, math.sqrt(0.26)]
+    # Sub1 = [0.3, 0.8, sqrt(0.27), 0, ...]  (unit length)
+    sub_comps = [0.3, 0.8, math.sqrt(0.27)]
     emb_s = _pad_to_768(sub_comps)
 
     pub_lines = (
@@ -1075,8 +1085,8 @@ def test_reviewer_aggregation_with_weights_matches_manual_loop(tmp_path):
     pub_path.write_text(pub_lines)
     sub_path.write_text(sub_lines)
 
-    # Weights: A=2.0 (boost), B=0.5 (penalty)
-    weights_meta = {"A": {"weight": 2.0}, "B": {"weight": 0.5}}
+    # Weights: A=5.0 (boost), B=0.1 (penalty)
+    weights_meta = {"A": {"weight": 5.0}, "B": {"weight": 0.1}}
     with open(tmp_path / "specter_reviewer_paper_data.json", "w") as f:
         json.dump(weights_meta, f)
 
@@ -1088,12 +1098,17 @@ def test_reviewer_aggregation_with_weights_matches_manual_loop(tmp_path):
         logit = torch.logit(torch.tensor(score).clamp(epsilon, 1 - epsilon), eps=epsilon)
         return torch.sigmoid(logit + torch.log(torch.tensor(w).clamp(min=epsilon))).item()
 
-    w_a = apply_weight(0.7, 2.0)
-    w_b = apply_weight(0.5, 0.5)
-    expected = round((w_a + w_b) / 2, 4)
+    w_a = apply_weight(0.3, 5.0)
+    w_b = apply_weight(0.8, 0.1)
 
     rev1_idx = predictor.reviewer_ids.index("~Rev1")
-    assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == expected
+    rev2_idx = predictor.reviewer_ids.index("~Rev2")
+
+    # Exact values match
+    assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == round(w_a, 4)
+    assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == round(w_b, 4)
+    # Ordering flips: raw scores had Rev2 > Rev1; weights make Rev1 > Rev2
+    assert predictor.scores_matrix[0, rev1_idx].item() > predictor.scores_matrix[0, rev2_idx].item()
 
 
 def test_reviewer_aggregation_skips_bad_embeddings(tmp_path):

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -878,12 +878,14 @@ def test_reviewer_aggregation_max_matches_manual_loop(tmp_path):
     predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
 
     assert predictor.test_id_list == ["Sub1"]
-    assert predictor.reviewer_ids == ["~Rev1", "~Rev2"]
+    assert set(predictor.reviewer_ids) == {"~Rev1", "~Rev2"}
     assert predictor.scores_matrix.shape == (1, 2)
 
-    # Manual reference: max over each reviewer's papers
-    assert round(predictor.scores_matrix[0, 0].item(), 4) == 0.7000  # Rev1: max(0.3, 0.7)
-    assert round(predictor.scores_matrix[0, 1].item(), 4) == 0.5000  # Rev2: max(0.7, 0.2)
+    # Look up scores by reviewer id (order is non-deterministic)
+    rev1_idx = predictor.reviewer_ids.index("~Rev1")
+    rev2_idx = predictor.reviewer_ids.index("~Rev2")
+    assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == 0.7000  # Rev1: max(0.3, 0.7)
+    assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == 0.5000  # Rev2: max(0.7, 0.2)
 
 
 def test_reviewer_aggregation_average_matches_manual_loop(tmp_path):
@@ -940,11 +942,13 @@ def test_reviewer_aggregation_average_matches_manual_loop(tmp_path):
     predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
 
     assert predictor.test_id_list == ["Sub1"]
-    assert predictor.reviewer_ids == ["~Rev1", "~Rev2"]
+    assert set(predictor.reviewer_ids) == {"~Rev1", "~Rev2"}
     assert predictor.scores_matrix.shape == (1, 2)
 
-    assert round(predictor.scores_matrix[0, 0].item(), 4) == round((0.3 + 0.7) / 2, 4)
-    assert round(predictor.scores_matrix[0, 1].item(), 4) == round((0.7 + 0.2 + 0.4) / 3, 4)
+    rev1_idx = predictor.reviewer_ids.index("~Rev1")
+    rev2_idx = predictor.reviewer_ids.index("~Rev2")
+    assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == round((0.3 + 0.7) / 2, 4)
+    assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == round((0.7 + 0.2 + 0.4) / 3, 4)
 
 
 def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
@@ -1004,13 +1008,15 @@ def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
     predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
 
     assert predictor.test_id_list == ["Sub1"]
-    assert predictor.reviewer_ids == ["~Rev1", "~Rev2"]
+    assert set(predictor.reviewer_ids) == {"~Rev1", "~Rev2"}
     assert predictor.scores_matrix.shape == (1, 2)
 
+    rev1_idx = predictor.reviewer_ids.index("~Rev1")
+    rev2_idx = predictor.reviewer_ids.index("~Rev2")
     # Rev1 papers [A=0.1, B=0.9] -> median = 0.5
-    assert round(predictor.scores_matrix[0, 0].item(), 4) == 0.5000
+    assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == 0.5000
     # Rev2 papers [C=0.2, D=0.6, E=0.4] -> median = 0.4
-    assert round(predictor.scores_matrix[0, 1].item(), 4) == 0.4000
+    assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == 0.4000
 
 
 def test_reviewer_aggregation_with_weights_matches_manual_loop(tmp_path):
@@ -1076,7 +1082,8 @@ def test_reviewer_aggregation_with_weights_matches_manual_loop(tmp_path):
     w_b = apply_weight(0.5, 0.5)
     expected = round((w_a + w_b) / 2, 4)
 
-    assert round(predictor.scores_matrix[0, 0].item(), 4) == expected
+    rev1_idx = predictor.reviewer_ids.index("~Rev1")
+    assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == expected
 
 
 def test_reviewer_aggregation_skips_bad_embeddings(tmp_path):

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -816,231 +816,309 @@ def test_all_scores_skips_reviewer_with_only_bad_embeddings(tmp_path):
     assert score == score, "Score must not be NaN"
 
 
-@pytest.mark.parametrize("aggregation_mode,use_weights", [
-    ("max", False),
-    ("average", False),
-    ("percentile", False),
-    ("max", True),
-    ("average", True),
-    ("percentile", True),
-])
-def test_vectorized_aggregation_matches_reference_loop(tmp_path, aggregation_mode, use_weights):
-    """Regression for PR #386: verify vectorized reviewer aggregation produces
-    the same scores as the pre-change loop-based implementation.
+def test_reviewer_aggregation_max_matches_manual_loop(tmp_path):
+    """The vectorized max-score aggregation must match a plain Python loop.
 
-    Uses hand-crafted embeddings so p2p_aff values are deterministic.
-    Reviewers have varying paper counts (tests padding/masking).
-    One paper has a zero-length embedding (tests bad_id filtering).
+    Setup: one submission, two reviewers.
+      Rev1 has papers [A, B] with p2p scores [0.3, 0.7]
+      Rev2 has papers [B, C] with p2p scores [0.5, 0.2]
+    Expected: Rev1=0.7, Rev2=0.5
     """
-    work_dir = tmp_path / "work"
-    work_dir.mkdir()
-
-    predictor = specter2_scincl.Specter2Predictor(
-        specter_dir="../expertise-utils/specter/",
-        work_dir=str(work_dir),
-        use_cuda=False,
-        normalize_scores=False,
-        average_score=(aggregation_mode == "average"),
-        max_score=(aggregation_mode == "max"),
-        percentile_select=83 if aggregation_mode == "percentile" else None,
-        venue_specific_weights=use_weights,
-    )
-
-    # --- 1. Archives: 3 reviewers with varying paper counts ---
     archive_dir = tmp_path / "archives"
     archive_dir.mkdir()
-    # Rev1: 2 papers
     (archive_dir / "~Rev1.jsonl").write_text(
-        json.dumps({"id": "p1", "content": {"title": "P1", "abstract": "A1"}}) + "\n"
-        + json.dumps({"id": "p2", "content": {"title": "P2", "abstract": "A2"}}) + "\n"
+        json.dumps({"id": "A", "content": {"title": "A", "abstract": "a"}}) + "\n"
+        + json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
     )
-    # Rev2: 3 papers (one will have bad embedding)
     (archive_dir / "~Rev2.jsonl").write_text(
-        json.dumps({"id": "p2", "content": {"title": "P2", "abstract": "A2"}}) + "\n"
-        + json.dumps({"id": "p3", "content": {"title": "P3", "abstract": "A3"}}) + "\n"
-        + json.dumps({"id": "p4", "content": {"title": "P4", "abstract": "A4"}}) + "\n"
-    )
-    # Rev3: 1 paper
-    (archive_dir / "~Rev3.jsonl").write_text(
-        json.dumps({"id": "p5", "content": {"title": "P5", "abstract": "A5"}}) + "\n"
+        json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
+        + json.dumps({"id": "C", "content": {"title": "C", "abstract": "c"}}) + "\n"
     )
 
-    archives_dataset = ArchivesDataset(archives_path=archive_dir)
-    predictor.set_archives_dataset(archives_dataset)
-
-    # --- 2. Submissions: 2 submissions ---
     sub_dir = tmp_path / "submissions"
     sub_dir.mkdir()
     (sub_dir / "Sub1.jsonl").write_text(
-        json.dumps({"id": "Sub1", "content": {"title": "S1", "abstract": "S1"}}) + "\n"
-    )
-    (sub_dir / "Sub2.jsonl").write_text(
-        json.dumps({"id": "Sub2", "content": {"title": "S2", "abstract": "S2"}}) + "\n"
+        json.dumps({"id": "Sub1", "content": {"title": "S", "abstract": "s"}}) + "\n"
     )
 
-    submissions_dataset = SubmissionsDataset(submissions_path=sub_dir)
-    predictor.set_submissions_dataset(submissions_dataset)
+    predictor = specter2_scincl.Specter2Predictor(
+        specter_dir="../expertise-utils/specter/",
+        work_dir=str(tmp_path),
+        use_cuda=False,
+        normalize_scores=False,
+        average_score=False,
+        max_score=True,
+    )
+    predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))
+    predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
 
-    # --- 3. Hand-crafted embeddings ---
-    # Use 768-dim vectors where unit vectors produce predictable dot products.
-    # After load_emb_file normalization, e_i stays e_i (already unit length).
-    def unit_vec(i):
-        v = [0.0] * 768
-        v[i] = 1.0
-        return v
-
-    # Publications:
-    #   p1 = e0, p2 = e1, p3 = e2, p4 = e3, p5 = e4
-    # Submissions:
-    #   Sub1 = (e0 + e1) / sqrt(2)
-    #   Sub2 = (e1 + e2) / sqrt(2)
-    #
-    # Expected raw p2p_aff (before normalization, which is disabled):
-    #           p1    p2    p3    p4    p5
-    #   Sub1  1/√2  1/√2   0     0     0
-    #   Sub2   0    1/√2  1/√2   0     0
-    #
-    # p4 has a zero-length embedding -> added to train_bad_id_set.
-    # So Rev2 effectively has papers [p2, p3] after filtering.
+    # Embeddings are chosen so that Sub1·A=0.3, Sub1·B=0.7, Sub1·C=0.2
+    # We use 3-dim vectors for clarity (the predictor pads to 768 internally).
+    emb_a = [0.3, 0.0, 0.0]          # A
+    emb_b = [0.0, 0.7, 0.0]          # B
+    emb_c = [0.0, 0.0, 0.2]          # C
+    emb_s = [1.0, 1.0, 1.0]          # Sub1  -> dot(A)=0.3, dot(B)=0.7, dot(C)=0.2
 
     pub_lines = (
-        json.dumps({"paper_id": "p1", "embedding": unit_vec(0)}) + "\n"
-        + json.dumps({"paper_id": "p2", "embedding": unit_vec(1)}) + "\n"
-        + json.dumps({"paper_id": "p3", "embedding": unit_vec(2)}) + "\n"
-        + json.dumps({"paper_id": "p4", "embedding": []}) + "\n"  # bad embedding
-        + json.dumps({"paper_id": "p5", "embedding": unit_vec(4)}) + "\n"
+        json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"
+        + json.dumps({"paper_id": "B", "embedding": emb_b}) + "\n"
+        + json.dumps({"paper_id": "C", "embedding": emb_c}) + "\n"
     )
+    sub_lines = json.dumps({"paper_id": "Sub1", "embedding": emb_s}) + "\n"
 
-    def sub_vec(i, j):
-        v = [0.0] * 768
-        v[i] = 1.0 / (2 ** 0.5)
-        v[j] = 1.0 / (2 ** 0.5)
-        return v
-
-    sub_lines = (
-        json.dumps({"paper_id": "Sub1", "embedding": sub_vec(0, 1)}) + "\n"
-        + json.dumps({"paper_id": "Sub2", "embedding": sub_vec(1, 2)}) + "\n"
-    )
-
-    pub_path = work_dir / "pub2vec_specter.jsonl"
-    sub_path = work_dir / "sub2vec_specter.jsonl"
+    pub_path = tmp_path / "pub2vec_specter.jsonl"
+    sub_path = tmp_path / "sub2vec_specter.jsonl"
     pub_path.write_text(pub_lines)
     sub_path.write_text(sub_lines)
 
-    # --- 4. Venue weights metadata (if needed) ---
-    if use_weights:
-        weights_meta = {
-            "p1": {"weight": 2.0},
-            "p2": {"weight": 1.0},
-            "p3": {"weight": 0.5},
-            "p4": {"weight": 1.0},
-            "p5": {"weight": 3.0},
-        }
-        with open(work_dir / "specter_reviewer_paper_data.json", "w") as f:
-            json.dump(weights_meta, f)
-
-    # --- 5. Run the vectorized code ---
     predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
 
-    # --- 6. Compute reference scores with the old loop ---
-    # Load embeddings to reconstruct p2p_aff
-    with open(pub_path) as f:
-        pub_embs = {}
-        for line in f:
-            d = json.loads(line)
-            if d["embedding"]:
-                e = torch.tensor(d["embedding"], dtype=torch.float32)
-                e = e / (e.norm() + 1e-12)
-                pub_embs[d["paper_id"]] = e
+    assert predictor.test_id_list == ["Sub1"]
+    assert predictor.reviewer_ids == ["~Rev1", "~Rev2"]
+    assert predictor.scores_matrix.shape == (1, 2)
 
-    with open(sub_path) as f:
-        sub_embs = {}
-        for line in f:
-            d = json.loads(line)
-            e = torch.tensor(d["embedding"], dtype=torch.float32)
-            e = e / (e.norm() + 1e-12)
-            sub_embs[d["paper_id"]] = e
+    # Manual reference: max over each reviewer's papers
+    assert round(predictor.scores_matrix[0, 0].item(), 4) == 0.7000  # Rev1: max(0.3, 0.7)
+    assert round(predictor.scores_matrix[0, 1].item(), 4) == 0.5000  # Rev2: max(0.7, 0.2)
 
-    sub_ids = ["Sub1", "Sub2"]
-    pub_ids = ["p1", "p2", "p3", "p4", "p5"]
-    p2p = torch.zeros((2, 5), dtype=torch.float32)
-    for i, sid in enumerate(sub_ids):
-        for j, pid in enumerate(pub_ids):
-            if pid in pub_embs:
-                p2p[i, j] = sub_embs[sid].dot(pub_embs[pid]).item()
 
-    # Reviewer paper indices after bad_id filtering
-    reviewer_papers = {
-        "~Rev1": ["p1", "p2"],
-        "~Rev2": ["p2", "p3"],  # p4 filtered out
-        "~Rev3": ["p5"],
-    }
-    pub_id_to_idx = {pid: j for j, pid in enumerate(pub_ids)}
-
-    # Load weights if needed
-    weights = None
-    if use_weights:
-        with open(work_dir / "specter_reviewer_paper_data.json") as f:
-            weights_meta = json.load(f)
-        weights = torch.tensor([weights_meta.get(pid, {}).get("weight", 1.0) for pid in pub_ids], dtype=torch.float32)
-
-    ref_vectors = []
-    ref_reviewer_ids = []
-    for rev_id, papers in reviewer_papers.items():
-        paper_indices = [pub_id_to_idx[p] for p in papers]
-        train_paper_aff_j = p2p[:, paper_indices]
-
-        if use_weights:
-            train_weight_j = weights[paper_indices]
-            epsilon = 1e-8
-            logits = torch.logit(train_paper_aff_j.clamp(epsilon, 1 - epsilon), eps=epsilon)
-            log_w = torch.log(torch.clamp(train_weight_j, min=epsilon))
-            weighted_logits = logits + log_w.unsqueeze(0)
-            train_paper_aff_j = torch.sigmoid(weighted_logits)
-
-        if aggregation_mode == "percentile":
-            q = 0.83
-            all_paper_aff = torch.quantile(train_paper_aff_j, q, dim=1, interpolation='linear')
-        elif aggregation_mode == "average":
-            all_paper_aff = train_paper_aff_j.mean(dim=1)
-        elif aggregation_mode == "max":
-            all_paper_aff = train_paper_aff_j.max(dim=1)[0]
-
-        ref_vectors.append(all_paper_aff)
-        ref_reviewer_ids.append(rev_id)
-
-    ref_matrix = torch.stack(ref_vectors, dim=1)  # [2, 3]
-
-    # --- 7. Compare using the same dict-based pattern as compare_scores.py ---
-    actual_scores = {}
-    for i, sub_id in enumerate(predictor.test_id_list):
-        for j, rev_id in enumerate(predictor.reviewer_ids):
-            actual_scores[(sub_id, rev_id)] = round(float(predictor.scores_matrix[i, j]), 4)
-
-    ref_scores = {}
-    for i, sub_id in enumerate(sub_ids):
-        for j, rev_id in enumerate(ref_reviewer_ids):
-            ref_scores[(sub_id, rev_id)] = round(float(ref_matrix[i, j]), 4)
-
-    common = set(actual_scores.keys()) & set(ref_scores.keys())
-    diffs = []
-    for key in common:
-        if actual_scores[key] != ref_scores[key]:
-            diffs.append({
-                "submission_id": key[0],
-                "reviewer_id": key[1],
-                "score_actual": actual_scores[key],
-                "score_expected": ref_scores[key],
-                "delta": actual_scores[key] - ref_scores[key],
-            })
-
-    assert len(diffs) == 0, (
-        f"Score mismatch in mode={aggregation_mode}, weights={use_weights}: "
-        f"{len(diffs)} pairs differ out of {len(common)} total.\n"
-        + "\n".join(
-            f"  {d['submission_id']} / {d['reviewer_id']}: "
-            f"actual={d['score_actual']:.4f} expected={d['score_expected']:.4f} "
-            f"delta={d['delta']:+.4f}"
-            for d in diffs[:10]
-        )
+def test_reviewer_aggregation_average_matches_manual_loop(tmp_path):
+    """The vectorized average-score aggregation must match a plain Python loop."""
+    archive_dir = tmp_path / "archives"
+    archive_dir.mkdir()
+    (archive_dir / "~Rev1.jsonl").write_text(
+        json.dumps({"id": "A", "content": {"title": "A", "abstract": "a"}}) + "\n"
+        + json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
     )
+    (archive_dir / "~Rev2.jsonl").write_text(
+        json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
+        + json.dumps({"id": "C", "content": {"title": "C", "abstract": "c"}}) + "\n"
+        + json.dumps({"id": "D", "content": {"title": "D", "abstract": "d"}}) + "\n"
+    )
+
+    sub_dir = tmp_path / "submissions"
+    sub_dir.mkdir()
+    (sub_dir / "Sub1.jsonl").write_text(
+        json.dumps({"id": "Sub1", "content": {"title": "S", "abstract": "s"}}) + "\n"
+    )
+
+    predictor = specter2_scincl.Specter2Predictor(
+        specter_dir="../expertise-utils/specter/",
+        work_dir=str(tmp_path),
+        use_cuda=False,
+        normalize_scores=False,
+        average_score=True,
+        max_score=False,
+    )
+    predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))
+    predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
+
+    # Sub1·A=0.3, Sub1·B=0.7, Sub1·C=0.2, Sub1·D=0.4
+    emb_a = [0.3, 0.0, 0.0, 0.0]
+    emb_b = [0.0, 0.7, 0.0, 0.0]
+    emb_c = [0.0, 0.0, 0.2, 0.0]
+    emb_d = [0.0, 0.0, 0.0, 0.4]
+    emb_s = [1.0, 1.0, 1.0, 1.0]
+
+    pub_lines = (
+        json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"
+        + json.dumps({"paper_id": "B", "embedding": emb_b}) + "\n"
+        + json.dumps({"paper_id": "C", "embedding": emb_c}) + "\n"
+        + json.dumps({"paper_id": "D", "embedding": emb_d}) + "\n"
+    )
+    sub_lines = json.dumps({"paper_id": "Sub1", "embedding": emb_s}) + "\n"
+
+    pub_path = tmp_path / "pub2vec_specter.jsonl"
+    sub_path = tmp_path / "sub2vec_specter.jsonl"
+    pub_path.write_text(pub_lines)
+    sub_path.write_text(sub_lines)
+
+    predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
+
+    assert predictor.test_id_list == ["Sub1"]
+    assert predictor.reviewer_ids == ["~Rev1", "~Rev2"]
+    assert predictor.scores_matrix.shape == (1, 2)
+
+    assert round(predictor.scores_matrix[0, 0].item(), 4) == round((0.3 + 0.7) / 2, 4)
+    assert round(predictor.scores_matrix[0, 1].item(), 4) == round((0.7 + 0.2 + 0.4) / 3, 4)
+
+
+def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
+    """The vectorized percentile aggregation must match a plain Python loop."""
+    archive_dir = tmp_path / "archives"
+    archive_dir.mkdir()
+    (archive_dir / "~Rev1.jsonl").write_text(
+        json.dumps({"id": "A", "content": {"title": "A", "abstract": "a"}}) + "\n"
+        + json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
+    )
+    (archive_dir / "~Rev2.jsonl").write_text(
+        json.dumps({"id": "C", "content": {"title": "C", "abstract": "c"}}) + "\n"
+        + json.dumps({"id": "D", "content": {"title": "D", "abstract": "d"}}) + "\n"
+        + json.dumps({"id": "E", "content": {"title": "E", "abstract": "e"}}) + "\n"
+    )
+
+    sub_dir = tmp_path / "submissions"
+    sub_dir.mkdir()
+    (sub_dir / "Sub1.jsonl").write_text(
+        json.dumps({"id": "Sub1", "content": {"title": "S", "abstract": "s"}}) + "\n"
+    )
+
+    predictor = specter2_scincl.Specter2Predictor(
+        specter_dir="../expertise-utils/specter/",
+        work_dir=str(tmp_path),
+        use_cuda=False,
+        normalize_scores=False,
+        average_score=False,
+        max_score=False,
+        percentile_select=50,
+    )
+    predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))
+    predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
+
+    # Scores: A=0.1, B=0.9, C=0.2, D=0.6, E=0.4
+    emb_a = [0.1, 0.0, 0.0, 0.0, 0.0]
+    emb_b = [0.0, 0.9, 0.0, 0.0, 0.0]
+    emb_c = [0.0, 0.0, 0.2, 0.0, 0.0]
+    emb_d = [0.0, 0.0, 0.0, 0.6, 0.0]
+    emb_e = [0.0, 0.0, 0.0, 0.0, 0.4]
+    emb_s = [1.0, 1.0, 1.0, 1.0, 1.0]
+
+    pub_lines = (
+        json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"
+        + json.dumps({"paper_id": "B", "embedding": emb_b}) + "\n"
+        + json.dumps({"paper_id": "C", "embedding": emb_c}) + "\n"
+        + json.dumps({"paper_id": "D", "embedding": emb_d}) + "\n"
+        + json.dumps({"paper_id": "E", "embedding": emb_e}) + "\n"
+    )
+    sub_lines = json.dumps({"paper_id": "Sub1", "embedding": emb_s}) + "\n"
+
+    pub_path = tmp_path / "pub2vec_specter.jsonl"
+    sub_path = tmp_path / "sub2vec_specter.jsonl"
+    pub_path.write_text(pub_lines)
+    sub_path.write_text(sub_lines)
+
+    predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
+
+    assert predictor.test_id_list == ["Sub1"]
+    assert predictor.reviewer_ids == ["~Rev1", "~Rev2"]
+    assert predictor.scores_matrix.shape == (1, 2)
+
+    # Rev1 papers [A=0.1, B=0.9] -> median = 0.5
+    assert round(predictor.scores_matrix[0, 0].item(), 4) == 0.5000
+    # Rev2 papers [C=0.2, D=0.6, E=0.4] -> median = 0.4
+    assert round(predictor.scores_matrix[0, 1].item(), 4) == 0.4000
+
+
+def test_reviewer_aggregation_with_weights_matches_manual_loop(tmp_path):
+    """Venue-weighted aggregation must match a plain Python loop.
+
+    The weight is applied in logit space: sigmoid(logit(score) + log(weight)).
+    """
+    archive_dir = tmp_path / "archives"
+    archive_dir.mkdir()
+    (archive_dir / "~Rev1.jsonl").write_text(
+        json.dumps({"id": "A", "content": {"title": "A", "abstract": "a"}}) + "\n"
+        + json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
+    )
+
+    sub_dir = tmp_path / "submissions"
+    sub_dir.mkdir()
+    (sub_dir / "Sub1.jsonl").write_text(
+        json.dumps({"id": "Sub1", "content": {"title": "S", "abstract": "s"}}) + "\n"
+    )
+
+    predictor = specter2_scincl.Specter2Predictor(
+        specter_dir="../expertise-utils/specter/",
+        work_dir=str(tmp_path),
+        use_cuda=False,
+        normalize_scores=False,
+        average_score=True,
+        max_score=False,
+        venue_specific_weights=True,
+    )
+    predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))
+    predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
+
+    # Sub1·A=0.5, Sub1·B=0.5 (same score, different weights)
+    emb_a = [0.5, 0.0]
+    emb_b = [0.0, 0.5]
+    emb_s = [1.0, 1.0]
+
+    pub_lines = (
+        json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"
+        + json.dumps({"paper_id": "B", "embedding": emb_b}) + "\n"
+    )
+    sub_lines = json.dumps({"paper_id": "Sub1", "embedding": emb_s}) + "\n"
+
+    pub_path = tmp_path / "pub2vec_specter.jsonl"
+    sub_path = tmp_path / "sub2vec_specter.jsonl"
+    pub_path.write_text(pub_lines)
+    sub_path.write_text(sub_lines)
+
+    # Weights: A=2.0 (boost), B=0.5 (penalty)
+    weights_meta = {"A": {"weight": 2.0}, "B": {"weight": 0.5}}
+    with open(tmp_path / "specter_reviewer_paper_data.json", "w") as f:
+        json.dump(weights_meta, f)
+
+    predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
+
+    # Manual reference for weighted average
+    def apply_weight(score, w):
+        epsilon = 1e-8
+        logit = torch.logit(torch.tensor(score).clamp(epsilon, 1 - epsilon), eps=epsilon)
+        return torch.sigmoid(logit + torch.log(torch.tensor(w).clamp(min=epsilon))).item()
+
+    w_a = apply_weight(0.5, 2.0)
+    w_b = apply_weight(0.5, 0.5)
+    expected = round((w_a + w_b) / 2, 4)
+
+    assert round(predictor.scores_matrix[0, 0].item(), 4) == expected
+
+
+def test_reviewer_aggregation_skips_bad_embeddings(tmp_path):
+    """A reviewer whose only valid paper gets filtered as a bad embedding
+    must be dropped entirely (0-column matrix, not NaN).
+    """
+    archive_dir = tmp_path / "archives"
+    archive_dir.mkdir()
+    (archive_dir / "~Rev1.jsonl").write_text(
+        json.dumps({"id": "good_paper", "content": {"title": "G", "abstract": "g"}}) + "\n"
+    )
+    (archive_dir / "~Rev2.jsonl").write_text(
+        json.dumps({"id": "bad_paper", "content": {"title": "B", "abstract": "b"}}) + "\n"
+    )
+
+    sub_dir = tmp_path / "submissions"
+    sub_dir.mkdir()
+    (sub_dir / "Sub1.jsonl").write_text(
+        json.dumps({"id": "Sub1", "content": {"title": "S", "abstract": "s"}}) + "\n"
+    )
+
+    predictor = specter2_scincl.Specter2Predictor(
+        specter_dir="../expertise-utils/specter/",
+        work_dir=str(tmp_path),
+        use_cuda=False,
+        normalize_scores=False,
+        average_score=True,
+        max_score=False,
+    )
+    predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))
+    predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
+
+    good_emb = [0.5] * 768
+    pub_lines = (
+        json.dumps({"paper_id": "good_paper", "embedding": good_emb}) + "\n"
+        + json.dumps({"paper_id": "bad_paper", "embedding": []}) + "\n"
+    )
+    sub_lines = json.dumps({"paper_id": "Sub1", "embedding": good_emb}) + "\n"
+
+    pub_path = tmp_path / "pub2vec_specter.jsonl"
+    sub_path = tmp_path / "sub2vec_specter.jsonl"
+    pub_path.write_text(pub_lines)
+    sub_path.write_text(sub_lines)
+
+    predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
+
+    assert predictor.reviewer_ids == ["~Rev1"]
+    assert predictor.scores_matrix.shape == (1, 1)
+    assert predictor.scores_matrix[0, 0].item() == predictor.scores_matrix[0, 0].item()  # not NaN

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -914,6 +914,13 @@ def test_reviewer_aggregation_max_matches_manual_loop(tmp_path):
     # Ordering: Rev1 scored higher than Rev2 for Sub1
     assert predictor.scores_matrix[0, rev1_idx].item() > predictor.scores_matrix[0, rev2_idx].item()
 
+    # Also verify against a reference loop over the same p2p matrix
+    reviewer_papers = {"~Rev1": ["A", "B"], "~Rev2": ["C", "D"]}
+    _, reference = _reference_loop(pub_path, sub_path, reviewer_papers, mode="max")
+    for rev_id, expected in reference.items():
+        col = predictor.reviewer_ids.index(rev_id)
+        assert round(predictor.scores_matrix[0, col].item(), 4) == round(expected[0].item(), 4)
+
 
 def test_reviewer_aggregation_average_matches_manual_loop(tmp_path):
     """The vectorized average-score aggregation must match a plain Python loop."""
@@ -978,6 +985,12 @@ def test_reviewer_aggregation_average_matches_manual_loop(tmp_path):
     assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == round((0.4 + 0.1 + 0.3) / 3, 4)
     # Ordering: Rev1 scored higher than Rev2 for Sub1
     assert predictor.scores_matrix[0, rev1_idx].item() > predictor.scores_matrix[0, rev2_idx].item()
+
+    reviewer_papers = {"~Rev1": ["A", "B"], "~Rev2": ["C", "D", "E"]}
+    _, reference = _reference_loop(pub_path, sub_path, reviewer_papers, mode="average")
+    for rev_id, expected in reference.items():
+        col = predictor.reviewer_ids.index(rev_id)
+        assert round(predictor.scores_matrix[0, col].item(), 4) == round(expected[0].item(), 4)
 
 
 def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
@@ -1046,6 +1059,12 @@ def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
     assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == 0.3000
     # Ordering: Rev1 scored higher than Rev2 for Sub1
     assert predictor.scores_matrix[0, rev1_idx].item() > predictor.scores_matrix[0, rev2_idx].item()
+
+    reviewer_papers = {"~Rev1": ["A", "B"], "~Rev2": ["C", "D", "E"]}
+    _, reference = _reference_loop(pub_path, sub_path, reviewer_papers, mode="percentile", percentile=50)
+    for rev_id, expected in reference.items():
+        col = predictor.reviewer_ids.index(rev_id)
+        assert round(predictor.scores_matrix[0, col].item(), 4) == round(expected[0].item(), 4)
 
 
 def test_reviewer_aggregation_with_weights_preserves_and_flips_ordering(tmp_path):
@@ -1121,6 +1140,12 @@ def test_reviewer_aggregation_with_weights_preserves_and_flips_ordering(tmp_path
     # Ordering flips: raw scores had Rev2 > Rev1; weights make Rev1 > Rev2
     assert predictor.scores_matrix[0, rev1_idx].item() > predictor.scores_matrix[0, rev2_idx].item()
 
+    reviewer_papers = {"~Rev1": ["A"], "~Rev2": ["B"]}
+    _, reference = _reference_loop(pub_path, sub_path, reviewer_papers, mode="average", weights={"A": 5.0, "B": 0.1})
+    for rev_id, expected in reference.items():
+        col = predictor.reviewer_ids.index(rev_id)
+        assert round(predictor.scores_matrix[0, col].item(), 4) == round(expected[0].item(), 4)
+
 
 def test_reviewer_aggregation_skips_bad_embeddings(tmp_path):
     """Reviewers whose only paper has a bad (empty) embedding are dropped.
@@ -1166,6 +1191,12 @@ def test_reviewer_aggregation_skips_bad_embeddings(tmp_path):
     assert predictor.reviewer_ids == ["~Rev1"]
     assert predictor.scores_matrix.shape == (1, 1)
     assert predictor.scores_matrix[0, 0].item() == predictor.scores_matrix[0, 0].item()  # not NaN
+
+    reviewer_papers = {"~Rev1": ["good_paper"]}
+    _, reference = _reference_loop(pub_path, sub_path, reviewer_papers, mode="average")
+    for rev_id, expected in reference.items():
+        col = predictor.reviewer_ids.index(rev_id)
+        assert round(predictor.scores_matrix[0, col].item(), 4) == round(expected[0].item(), 4)
 
 
 def _reference_loop(pub_path, sub_path, reviewer_papers, mode="max", percentile=None, weights=None):

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -1166,3 +1166,140 @@ def test_reviewer_aggregation_skips_bad_embeddings(tmp_path):
     assert predictor.reviewer_ids == ["~Rev1"]
     assert predictor.scores_matrix.shape == (1, 1)
     assert predictor.scores_matrix[0, 0].item() == predictor.scores_matrix[0, 0].item()  # not NaN
+
+
+def _reference_loop(pub_path, sub_path, reviewer_papers, mode="max", percentile=None, weights=None):
+    """Compute reviewer scores with a plain Python loop over the p2p matrix.
+
+    Replicates load_emb_file's L2-normalization and all_scores' reduction
+    exactly, using Python lists instead of vectorized ops.
+    """
+    def _load_norm(path):
+        ids, embs = [], []
+        with open(path) as f:
+            for line in f:
+                d = json.loads(line)
+                emb = d['embedding']
+                if len(emb) == 0:
+                    emb = [0.0] * 768
+                t = torch.tensor(emb, dtype=torch.float32)
+                t = t / (t.norm() + 1e-12)
+                ids.append(d['paper_id'])
+                embs.append(t)
+        return ids, torch.stack(embs)
+
+    train_ids, train_embs = _load_norm(pub_path)
+    test_ids, test_embs = _load_norm(sub_path)
+    p2p = test_embs @ train_embs.T
+
+    train_id_to_idx = {pid: i for i, pid in enumerate(train_ids)}
+    results = {}
+    for rev_id, paper_ids in reviewer_papers.items():
+        idxs = [train_id_to_idx[pid] for pid in paper_ids]
+        scores = p2p[:, idxs]
+        if weights is not None:
+            epsilon = 1e-8
+            w = torch.tensor([weights.get(pid, 1.0) for pid in paper_ids], dtype=torch.float32)
+            logits = torch.logit(scores.clamp(epsilon, 1 - epsilon), eps=epsilon)
+            log_w = torch.log(w.clamp(min=epsilon))
+            scores = torch.sigmoid(logits + log_w.unsqueeze(0))
+        if percentile is not None:
+            q = max(0.0, min(1.0, percentile / 100.0))
+            results[rev_id] = torch.quantile(scores, q, dim=1, interpolation='linear')
+        elif mode == "average":
+            results[rev_id] = scores.mean(dim=1)
+        elif mode == "max":
+            results[rev_id] = scores.max(dim=1)[0]
+    return test_ids, results
+
+
+@pytest.mark.parametrize("mode,avg,max_score,percentile", [
+    ("max", False, True, None),
+    ("average", True, False, None),
+    ("percentile", False, True, 50),
+])
+def test_scale_matches_reference_loop(tmp_path, mode, avg, max_score, percentile):
+    """Scale test: 30 submissions, 20 reviewers, 1-15 papers each.
+
+    Uses a shared pool of 100 papers. Each reviewer draws 1-15 random papers.
+    Submissions are random unit vectors. Asserts vectorized output matches
+    the reference loop exactly in all 3 reduction modes.
+    """
+    archive_dir = tmp_path / "archives"
+    archive_dir.mkdir()
+
+    rng = np.random.default_rng(seed=42)
+    num_papers = 100
+    num_reviewers = 20
+    num_submissions = 30
+
+    paper_ids = [f"P{i}" for i in range(1, num_papers + 1)]
+    reviewer_ids = [f"~Rev{i}" for i in range(1, num_reviewers + 1)]
+    submission_ids = [f"Sub{i}" for i in range(1, num_submissions + 1)]
+
+    reviewer_papers = {}
+    for rev_id in reviewer_ids:
+        n_papers = rng.integers(1, 16)
+        papers = rng.choice(paper_ids, size=n_papers, replace=False).tolist()
+        reviewer_papers[rev_id] = papers
+        lines = "\n".join(
+            json.dumps({"id": pid, "content": {"title": pid, "abstract": pid}})
+            for pid in papers
+        ) + "\n"
+        (archive_dir / f"{rev_id}.jsonl").write_text(lines)
+
+    sub_dir = tmp_path / "submissions"
+    sub_dir.mkdir()
+    for sid in submission_ids:
+        (sub_dir / f"{sid}.jsonl").write_text(
+            json.dumps({"id": sid, "content": {"title": sid, "abstract": sid}}) + "\n"
+        )
+
+    predictor = _make_predictor(
+        tmp_path,
+        average_score=avg,
+        max_score=max_score,
+        percentile_select=percentile,
+    )
+    predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))
+    predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
+
+    pub_embs = {}
+    for i, pid in enumerate(paper_ids):
+        vec = [0.0] * num_papers
+        vec[i] = 1.0
+        pub_embs[pid] = _pad_to_768(vec)
+
+    sub_embs = {}
+    for sid in submission_ids:
+        vec = rng.random(num_papers)
+        t = torch.tensor(vec, dtype=torch.float32)
+        t = t / t.norm()
+        sub_embs[sid] = _pad_to_768(t.tolist())
+
+    pub_lines = "\n".join(
+        json.dumps({"paper_id": pid, "embedding": emb}) for pid, emb in pub_embs.items()
+    ) + "\n"
+    sub_lines = "\n".join(
+        json.dumps({"paper_id": sid, "embedding": emb}) for sid, emb in sub_embs.items()
+    ) + "\n"
+
+    pub_path = tmp_path / "pub2vec_specter.jsonl"
+    sub_path = tmp_path / "sub2vec_specter.jsonl"
+    pub_path.write_text(pub_lines)
+    sub_path.write_text(sub_lines)
+
+    predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
+
+    test_ids, reference = _reference_loop(
+        pub_path, sub_path, reviewer_papers, mode=mode, percentile=percentile
+    )
+
+    assert predictor.test_id_list == test_ids
+    assert set(predictor.reviewer_ids) == set(reviewer_papers.keys())
+    assert predictor.scores_matrix.shape == (num_submissions, num_reviewers)
+
+    for rev_id, expected in reference.items():
+        col = predictor.reviewer_ids.index(rev_id)
+        for row in range(num_submissions):
+            assert round(predictor.scores_matrix[row, col].item(), 4) == round(expected[row].item(), 4)

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -816,6 +816,11 @@ def test_all_scores_skips_reviewer_with_only_bad_embeddings(tmp_path):
     assert score == score, "Score must not be NaN"
 
 
+def _pad_to_768(emb):
+    """Pad a short embedding list to 768 dimensions with zeros."""
+    return emb + [0.0] * (768 - len(emb))
+
+
 def test_reviewer_aggregation_max_matches_manual_loop(tmp_path):
     """The vectorized max-score aggregation must match a plain Python loop.
 
@@ -853,11 +858,10 @@ def test_reviewer_aggregation_max_matches_manual_loop(tmp_path):
     predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
 
     # Embeddings are chosen so that Sub1·A=0.3, Sub1·B=0.7, Sub1·C=0.2
-    # We use 3-dim vectors for clarity (the predictor pads to 768 internally).
-    emb_a = [0.3, 0.0, 0.0]          # A
-    emb_b = [0.0, 0.7, 0.0]          # B
-    emb_c = [0.0, 0.0, 0.2]          # C
-    emb_s = [1.0, 1.0, 1.0]          # Sub1  -> dot(A)=0.3, dot(B)=0.7, dot(C)=0.2
+    emb_a = _pad_to_768([0.3, 0.0, 0.0])          # A
+    emb_b = _pad_to_768([0.0, 0.7, 0.0])          # B
+    emb_c = _pad_to_768([0.0, 0.0, 0.2])          # C
+    emb_s = _pad_to_768([1.0, 1.0, 1.0])          # Sub1  -> dot(A)=0.3, dot(B)=0.7, dot(C)=0.2
 
     pub_lines = (
         json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"
@@ -914,11 +918,11 @@ def test_reviewer_aggregation_average_matches_manual_loop(tmp_path):
     predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
 
     # Sub1·A=0.3, Sub1·B=0.7, Sub1·C=0.2, Sub1·D=0.4
-    emb_a = [0.3, 0.0, 0.0, 0.0]
-    emb_b = [0.0, 0.7, 0.0, 0.0]
-    emb_c = [0.0, 0.0, 0.2, 0.0]
-    emb_d = [0.0, 0.0, 0.0, 0.4]
-    emb_s = [1.0, 1.0, 1.0, 1.0]
+    emb_a = _pad_to_768([0.3, 0.0, 0.0, 0.0])
+    emb_b = _pad_to_768([0.0, 0.7, 0.0, 0.0])
+    emb_c = _pad_to_768([0.0, 0.0, 0.2, 0.0])
+    emb_d = _pad_to_768([0.0, 0.0, 0.0, 0.4])
+    emb_s = _pad_to_768([1.0, 1.0, 1.0, 1.0])
 
     pub_lines = (
         json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"
@@ -976,12 +980,12 @@ def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
     predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
 
     # Scores: A=0.1, B=0.9, C=0.2, D=0.6, E=0.4
-    emb_a = [0.1, 0.0, 0.0, 0.0, 0.0]
-    emb_b = [0.0, 0.9, 0.0, 0.0, 0.0]
-    emb_c = [0.0, 0.0, 0.2, 0.0, 0.0]
-    emb_d = [0.0, 0.0, 0.0, 0.6, 0.0]
-    emb_e = [0.0, 0.0, 0.0, 0.0, 0.4]
-    emb_s = [1.0, 1.0, 1.0, 1.0, 1.0]
+    emb_a = _pad_to_768([0.1, 0.0, 0.0, 0.0, 0.0])
+    emb_b = _pad_to_768([0.0, 0.9, 0.0, 0.0, 0.0])
+    emb_c = _pad_to_768([0.0, 0.0, 0.2, 0.0, 0.0])
+    emb_d = _pad_to_768([0.0, 0.0, 0.0, 0.6, 0.0])
+    emb_e = _pad_to_768([0.0, 0.0, 0.0, 0.0, 0.4])
+    emb_s = _pad_to_768([1.0, 1.0, 1.0, 1.0, 1.0])
 
     pub_lines = (
         json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"
@@ -1040,9 +1044,9 @@ def test_reviewer_aggregation_with_weights_matches_manual_loop(tmp_path):
     predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
 
     # Sub1·A=0.5, Sub1·B=0.5 (same score, different weights)
-    emb_a = [0.5, 0.0]
-    emb_b = [0.0, 0.5]
-    emb_s = [1.0, 1.0]
+    emb_a = _pad_to_768([0.5, 0.0])
+    emb_b = _pad_to_768([0.0, 0.5])
+    emb_s = _pad_to_768([1.0, 1.0])
 
     pub_lines = (
         json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"

--- a/tests/test_specter2scincl.py
+++ b/tests/test_specter2scincl.py
@@ -7,6 +7,7 @@ import json
 import pytest
 import numpy as np
 import torch
+import math
 from expertise.dataset import ArchivesDataset, SubmissionsDataset
 from expertise.models import specter2_scincl
 import redisai
@@ -824,9 +825,9 @@ def _pad_to_768(emb):
 def test_reviewer_aggregation_max_matches_manual_loop(tmp_path):
     """The vectorized max-score aggregation must match a plain Python loop.
 
-    Setup: one submission, two reviewers.
+    Setup: one submission, two reviewers with no shared papers.
       Rev1 has papers [A, B] with p2p scores [0.3, 0.7]
-      Rev2 has papers [B, C] with p2p scores [0.5, 0.2]
+      Rev2 has papers [C, D] with p2p scores [0.5, 0.2]
     Expected: Rev1=0.7, Rev2=0.5
     """
     archive_dir = tmp_path / "archives"
@@ -836,8 +837,8 @@ def test_reviewer_aggregation_max_matches_manual_loop(tmp_path):
         + json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
     )
     (archive_dir / "~Rev2.jsonl").write_text(
-        json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
-        + json.dumps({"id": "C", "content": {"title": "C", "abstract": "c"}}) + "\n"
+        json.dumps({"id": "C", "content": {"title": "C", "abstract": "c"}}) + "\n"
+        + json.dumps({"id": "D", "content": {"title": "D", "abstract": "d"}}) + "\n"
     )
 
     sub_dir = tmp_path / "submissions"
@@ -857,74 +858,15 @@ def test_reviewer_aggregation_max_matches_manual_loop(tmp_path):
     predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))
     predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
 
-    # Embeddings are chosen so that Sub1·A=0.3, Sub1·B=0.7, Sub1·C=0.2
-    emb_a = _pad_to_768([0.3, 0.0, 0.0])          # A
-    emb_b = _pad_to_768([0.0, 0.7, 0.0])          # B
-    emb_c = _pad_to_768([0.0, 0.0, 0.2])          # C
-    emb_s = _pad_to_768([1.0, 1.0, 1.0])          # Sub1  -> dot(A)=0.3, dot(B)=0.7, dot(C)=0.2
-
-    pub_lines = (
-        json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"
-        + json.dumps({"paper_id": "B", "embedding": emb_b}) + "\n"
-        + json.dumps({"paper_id": "C", "embedding": emb_c}) + "\n"
-    )
-    sub_lines = json.dumps({"paper_id": "Sub1", "embedding": emb_s}) + "\n"
-
-    pub_path = tmp_path / "pub2vec_specter.jsonl"
-    sub_path = tmp_path / "sub2vec_specter.jsonl"
-    pub_path.write_text(pub_lines)
-    sub_path.write_text(sub_lines)
-
-    predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
-
-    assert predictor.test_id_list == ["Sub1"]
-    assert set(predictor.reviewer_ids) == {"~Rev1", "~Rev2"}
-    assert predictor.scores_matrix.shape == (1, 2)
-
-    # Look up scores by reviewer id (order is non-deterministic)
-    rev1_idx = predictor.reviewer_ids.index("~Rev1")
-    rev2_idx = predictor.reviewer_ids.index("~Rev2")
-    assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == 0.7000  # Rev1: max(0.3, 0.7)
-    assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == 0.5000  # Rev2: max(0.7, 0.2)
-
-
-def test_reviewer_aggregation_average_matches_manual_loop(tmp_path):
-    """The vectorized average-score aggregation must match a plain Python loop."""
-    archive_dir = tmp_path / "archives"
-    archive_dir.mkdir()
-    (archive_dir / "~Rev1.jsonl").write_text(
-        json.dumps({"id": "A", "content": {"title": "A", "abstract": "a"}}) + "\n"
-        + json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
-    )
-    (archive_dir / "~Rev2.jsonl").write_text(
-        json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
-        + json.dumps({"id": "C", "content": {"title": "C", "abstract": "c"}}) + "\n"
-        + json.dumps({"id": "D", "content": {"title": "D", "abstract": "d"}}) + "\n"
-    )
-
-    sub_dir = tmp_path / "submissions"
-    sub_dir.mkdir()
-    (sub_dir / "Sub1.jsonl").write_text(
-        json.dumps({"id": "Sub1", "content": {"title": "S", "abstract": "s"}}) + "\n"
-    )
-
-    predictor = specter2_scincl.Specter2Predictor(
-        specter_dir="../expertise-utils/specter/",
-        work_dir=str(tmp_path),
-        use_cuda=False,
-        normalize_scores=False,
-        average_score=True,
-        max_score=False,
-    )
-    predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))
-    predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
-
-    # Sub1·A=0.3, Sub1·B=0.7, Sub1·C=0.2, Sub1·D=0.4
-    emb_a = _pad_to_768([0.3, 0.0, 0.0, 0.0])
-    emb_b = _pad_to_768([0.0, 0.7, 0.0, 0.0])
-    emb_c = _pad_to_768([0.0, 0.0, 0.2, 0.0])
-    emb_d = _pad_to_768([0.0, 0.0, 0.0, 0.4])
-    emb_s = _pad_to_768([1.0, 1.0, 1.0, 1.0])
+    # Basis vectors for publications; submission is a unit vector with chosen
+    # components so dot(sub, e_i) equals the desired p2p score after normalization.
+    emb_a = _pad_to_768([1.0])                         # e0
+    emb_b = _pad_to_768([0.0, 1.0])                    # e1
+    emb_c = _pad_to_768([0.0, 0.0, 1.0])               # e2
+    emb_d = _pad_to_768([0.0, 0.0, 0.0, 1.0])          # e3
+    # Sub1 = [0.3, 0.7, 0.5, 0.2, sqrt(0.13), 0, ...]  (unit length)
+    sub_comps = [0.3, 0.7, 0.5, 0.2, math.sqrt(0.13)]
+    emb_s = _pad_to_768(sub_comps)
 
     pub_lines = (
         json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"
@@ -947,8 +889,74 @@ def test_reviewer_aggregation_average_matches_manual_loop(tmp_path):
 
     rev1_idx = predictor.reviewer_ids.index("~Rev1")
     rev2_idx = predictor.reviewer_ids.index("~Rev2")
-    assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == round((0.3 + 0.7) / 2, 4)
-    assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == round((0.7 + 0.2 + 0.4) / 3, 4)
+    assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == 0.7000  # Rev1: max(0.3, 0.7)
+    assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == 0.5000  # Rev2: max(0.5, 0.2)
+
+
+def test_reviewer_aggregation_average_matches_manual_loop(tmp_path):
+    """The vectorized average-score aggregation must match a plain Python loop."""
+    archive_dir = tmp_path / "archives"
+    archive_dir.mkdir()
+    (archive_dir / "~Rev1.jsonl").write_text(
+        json.dumps({"id": "A", "content": {"title": "A", "abstract": "a"}}) + "\n"
+        + json.dumps({"id": "B", "content": {"title": "B", "abstract": "b"}}) + "\n"
+    )
+    (archive_dir / "~Rev2.jsonl").write_text(
+        json.dumps({"id": "C", "content": {"title": "C", "abstract": "c"}}) + "\n"
+        + json.dumps({"id": "D", "content": {"title": "D", "abstract": "d"}}) + "\n"
+        + json.dumps({"id": "E", "content": {"title": "E", "abstract": "e"}}) + "\n"
+    )
+
+    sub_dir = tmp_path / "submissions"
+    sub_dir.mkdir()
+    (sub_dir / "Sub1.jsonl").write_text(
+        json.dumps({"id": "Sub1", "content": {"title": "S", "abstract": "s"}}) + "\n"
+    )
+
+    predictor = specter2_scincl.Specter2Predictor(
+        specter_dir="../expertise-utils/specter/",
+        work_dir=str(tmp_path),
+        use_cuda=False,
+        normalize_scores=False,
+        average_score=True,
+        max_score=False,
+    )
+    predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))
+    predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
+
+    emb_a = _pad_to_768([1.0])                         # e0
+    emb_b = _pad_to_768([0.0, 1.0])                    # e1
+    emb_c = _pad_to_768([0.0, 0.0, 1.0])               # e2
+    emb_d = _pad_to_768([0.0, 0.0, 0.0, 1.0])          # e3
+    emb_e = _pad_to_768([0.0, 0.0, 0.0, 0.0, 1.0])    # e4
+    # Sub1 = [0.2, 0.6, 0.4, 0.1, 0.3, sqrt(0.34), 0, ...]  (unit length)
+    sub_comps = [0.2, 0.6, 0.4, 0.1, 0.3, math.sqrt(0.34)]
+    emb_s = _pad_to_768(sub_comps)
+
+    pub_lines = (
+        json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"
+        + json.dumps({"paper_id": "B", "embedding": emb_b}) + "\n"
+        + json.dumps({"paper_id": "C", "embedding": emb_c}) + "\n"
+        + json.dumps({"paper_id": "D", "embedding": emb_d}) + "\n"
+        + json.dumps({"paper_id": "E", "embedding": emb_e}) + "\n"
+    )
+    sub_lines = json.dumps({"paper_id": "Sub1", "embedding": emb_s}) + "\n"
+
+    pub_path = tmp_path / "pub2vec_specter.jsonl"
+    sub_path = tmp_path / "sub2vec_specter.jsonl"
+    pub_path.write_text(pub_lines)
+    sub_path.write_text(sub_lines)
+
+    predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
+
+    assert predictor.test_id_list == ["Sub1"]
+    assert set(predictor.reviewer_ids) == {"~Rev1", "~Rev2"}
+    assert predictor.scores_matrix.shape == (1, 2)
+
+    rev1_idx = predictor.reviewer_ids.index("~Rev1")
+    rev2_idx = predictor.reviewer_ids.index("~Rev2")
+    assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == round((0.2 + 0.6) / 2, 4)
+    assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == round((0.4 + 0.1 + 0.3) / 3, 4)
 
 
 def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
@@ -983,13 +991,14 @@ def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
     predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))
     predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
 
-    # Scores: A=0.1, B=0.9, C=0.2, D=0.6, E=0.4
-    emb_a = _pad_to_768([0.1, 0.0, 0.0, 0.0, 0.0])
-    emb_b = _pad_to_768([0.0, 0.9, 0.0, 0.0, 0.0])
-    emb_c = _pad_to_768([0.0, 0.0, 0.2, 0.0, 0.0])
-    emb_d = _pad_to_768([0.0, 0.0, 0.0, 0.6, 0.0])
-    emb_e = _pad_to_768([0.0, 0.0, 0.0, 0.0, 0.4])
-    emb_s = _pad_to_768([1.0, 1.0, 1.0, 1.0, 1.0])
+    emb_a = _pad_to_768([1.0])                         # e0
+    emb_b = _pad_to_768([0.0, 1.0])                    # e1
+    emb_c = _pad_to_768([0.0, 0.0, 1.0])               # e2
+    emb_d = _pad_to_768([0.0, 0.0, 0.0, 1.0])          # e3
+    emb_e = _pad_to_768([0.0, 0.0, 0.0, 0.0, 1.0])    # e4
+    # Sub1 = [0.2, 0.6, 0.3, 0.5, 0.1, 0.5, 0, ...]  (unit length)
+    sub_comps = [0.2, 0.6, 0.3, 0.5, 0.1, 0.5]
+    emb_s = _pad_to_768(sub_comps)
 
     pub_lines = (
         json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"
@@ -1013,10 +1022,10 @@ def test_reviewer_aggregation_percentile_matches_manual_loop(tmp_path):
 
     rev1_idx = predictor.reviewer_ids.index("~Rev1")
     rev2_idx = predictor.reviewer_ids.index("~Rev2")
-    # Rev1 papers [A=0.1, B=0.9] -> median = 0.5
-    assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == 0.5000
-    # Rev2 papers [C=0.2, D=0.6, E=0.4] -> median = 0.4
-    assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == 0.4000
+    # Rev1 papers [A=0.2, B=0.6] -> median = 0.4
+    assert round(predictor.scores_matrix[0, rev1_idx].item(), 4) == 0.4000
+    # Rev2 papers [C=0.3, D=0.5, E=0.1] -> median = 0.3
+    assert round(predictor.scores_matrix[0, rev2_idx].item(), 4) == 0.3000
 
 
 def test_reviewer_aggregation_with_weights_matches_manual_loop(tmp_path):
@@ -1049,10 +1058,11 @@ def test_reviewer_aggregation_with_weights_matches_manual_loop(tmp_path):
     predictor.set_archives_dataset(ArchivesDataset(archives_path=archive_dir))
     predictor.set_submissions_dataset(SubmissionsDataset(submissions_path=sub_dir))
 
-    # Sub1·A=0.5, Sub1·B=0.5 (same score, different weights)
-    emb_a = _pad_to_768([0.5, 0.0])
-    emb_b = _pad_to_768([0.0, 0.5])
-    emb_s = _pad_to_768([1.0, 1.0])
+    emb_a = _pad_to_768([1.0])                         # e0
+    emb_b = _pad_to_768([0.0, 1.0])                    # e1
+    # Sub1 = [0.7, 0.5, sqrt(0.26), 0, ...]  (unit length)
+    sub_comps = [0.7, 0.5, math.sqrt(0.26)]
+    emb_s = _pad_to_768(sub_comps)
 
     pub_lines = (
         json.dumps({"paper_id": "A", "embedding": emb_a}) + "\n"
@@ -1072,13 +1082,13 @@ def test_reviewer_aggregation_with_weights_matches_manual_loop(tmp_path):
 
     predictor.all_scores(publications_path=pub_path, submissions_path=sub_path)
 
-    # Manual reference for weighted average
+    # Manual reference for weighted average (same formula as the predictor)
     def apply_weight(score, w):
         epsilon = 1e-8
         logit = torch.logit(torch.tensor(score).clamp(epsilon, 1 - epsilon), eps=epsilon)
         return torch.sigmoid(logit + torch.log(torch.tensor(w).clamp(min=epsilon))).item()
 
-    w_a = apply_weight(0.5, 2.0)
+    w_a = apply_weight(0.7, 2.0)
     w_b = apply_weight(0.5, 0.5)
     expected = round((w_a + w_b) / 2, 4)
 


### PR DESCRIPTION
The per-reviewer aggregation loop in `all_scores` slices the p2p matrix per reviewer, optionally applies venue weights in logit space, then reduces via `max(dim=1)`, `mean(dim=1)`, or `torch.quantile`. These 5 tests pin each reduction mode to a hand-computed reference so regressions in the aggregation math are caught in CI.

Score vectors are built from orthonormal basis embeddings so dot products are exact after `load_emb_file` L2-normalizes them. The tests verify:
- `max` picks the highest p2p score per reviewer and preserves ordering.
- `mean` averages across a reviewer's papers regardless of paper count.
- `percentile_select=50` (median) yields the expected quantile over the sliced column.
- Venue weights (`sigmoid(logit(score) + log(weight))`) can flip reviewer rankings when boost/penalty are strong enough.
- A reviewer whose only paper has an empty embedding is dropped entirely instead of producing a NaN.