### PR TITLE
Fix `/expertise/metadata` rejecting completed jobs (`status: RUN_EXPERTISE`)

### DIFF
--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -1128,13 +1128,11 @@ class ExpertiseCloudService(BaseExpertiseService):
         Gets the dataset metadata for a given job (submission/archive counts,
         missing profiles and publications) by reading metadata.json from GCS.
         """
+        # Read metadata.json straight from GCS, mirroring get_expertise_results.
+        # We deliberately do not gate on job status: the client polls
+        # get_expertise_status to 'Completed' before calling this, and the
+        # Redis-cached status is stale in the cloud flow anyway (never updated
+        # to COMPLETED once the pipeline finishes). If the artifact isn't there
+        # yet, get_job_metadata raises.
         redis_job = self.redis.load_job(job_id, user_id)
-        # The Redis-cached status is stale in the cloud flow; the authoritative
-        # status lives in the Vertex AI pipeline. Resolve it live (same source
-        # as get_expertise_status) instead of trusting redis_job.status.
-        cloud_status = self.cloud.get_job_status_by_job_id(user_id, redis_job)
-        if cloud_status['status'] != JobStatus.COMPLETED:
-            raise openreview.OpenReviewException(
-                f"Metadata not available - status: {cloud_status['status']} | description: {cloud_status['description']}"
-            )
         return self.cloud.get_job_metadata(user_id, redis_job.cloud_id)

--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -1129,8 +1129,12 @@ class ExpertiseCloudService(BaseExpertiseService):
         missing profiles and publications) by reading metadata.json from GCS.
         """
         redis_job = self.redis.load_job(job_id, user_id)
-        if redis_job.status != JobStatus.COMPLETED:
+        # The Redis-cached status is stale in the cloud flow; the authoritative
+        # status lives in the Vertex AI pipeline. Resolve it live (same source
+        # as get_expertise_status) instead of trusting redis_job.status.
+        cloud_status = self.cloud.get_job_status_by_job_id(user_id, redis_job)
+        if cloud_status['status'] != JobStatus.COMPLETED:
             raise openreview.OpenReviewException(
-                f"Metadata not available - status: {redis_job.status} | description: {redis_job.description}"
+                f"Metadata not available - status: {cloud_status['status']} | description: {cloud_status['description']}"
             )
         return self.cloud.get_job_metadata(user_id, redis_job.cloud_id)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='openreview-expertise',
-    version='2.2.3',
+    version='2.2.4',
     description='OpenReview paper-reviewer affinity modeling',
     url='https://github.com/openreview/openreview-expertise',
     author='OpenReview',

--- a/tests/test_expertise_cloud_service.py
+++ b/tests/test_expertise_cloud_service.py
@@ -474,9 +474,9 @@ class TestExpertiseCloudService():
 
         # Regression: the Redis-cached status is stale in the cloud flow (it is
         # never updated to COMPLETED once the Vertex AI pipeline finishes). The
-        # metadata endpoint must resolve the live pipeline status rather than
-        # trusting redis_job.status, otherwise a genuinely-complete job is
-        # rejected with "Metadata not available - status: RUN_EXPERTISE".
+        # metadata endpoint must serve the metadata.json artifact straight from
+        # GCS without gating on that stale status, otherwise a genuinely-complete
+        # job is rejected with "Metadata not available - status: RUN_EXPERTISE".
         stale_config = redis.load_job(job_id, openreview_context_cloud['config']['OPENREVIEW_USERNAME'])
         stale_config.status = JobStatus.RUN_EXPERTISE
         stale_config.description = JobDescription.VALS.value[JobStatus.RUN_EXPERTISE]

--- a/tests/test_expertise_cloud_service.py
+++ b/tests/test_expertise_cloud_service.py
@@ -472,6 +472,24 @@ class TestExpertiseCloudService():
         assert metadata_response.status_code == 200
         assert metadata_response.json == {"meta": "data"}
 
+        # Regression: the Redis-cached status is stale in the cloud flow (it is
+        # never updated to COMPLETED once the Vertex AI pipeline finishes). The
+        # metadata endpoint must resolve the live pipeline status rather than
+        # trusting redis_job.status, otherwise a genuinely-complete job is
+        # rejected with "Metadata not available - status: RUN_EXPERTISE".
+        stale_config = redis.load_job(job_id, openreview_context_cloud['config']['OPENREVIEW_USERNAME'])
+        stale_config.status = JobStatus.RUN_EXPERTISE
+        stale_config.description = JobDescription.VALS.value[JobStatus.RUN_EXPERTISE]
+        redis.save_job(stale_config)
+
+        metadata_response = test_client.get(
+            '/expertise/metadata',
+            headers=tmlr_client.headers,
+            query_string={'jobId': job_id},
+        )
+        assert metadata_response.status_code == 200, metadata_response.json
+        assert metadata_response.json == {"meta": "data"}
+
     @patch("expertise.service.utils.aip.PipelineJob")  # Mock PipelineJob to avoid calling AI Platform
     def test_group_group_scores(self, mock_pipeline_job, openreview_client, openreview_context_cloud, gcs_test_bucket, gcs_jobs_prefix):
         def setup_job_mocks():


### PR DESCRIPTION
## Summary

`GET /expertise/metadata` returned an error for jobs that were actually complete:

```
GET /expertise/metadata?jobId=qu36379fzz
{'message': 'Metadata not available - status: JobStatus.RUN_EXPERTISE | description: Job is running the selected expertise model to compute scores', 'name': 'InternalServerError'}
```

This removes the status gate from `ExpertiseCloudService.get_expertise_metadata`, so it reads `metadata.json` straight from GCS — exactly like `get_expertise_results`.

## Root cause

In the cloud flow the authoritative job status lives in the Vertex AI pipeline and is resolved live (`get_job_status_by_job_id` → `_resolve_job_status`). The status cached in Redis is **never updated to `COMPLETED`** once the pipeline finishes, so it stays at whatever it was last persisted as — typically `RUN_EXPERTISE`.

The metadata endpoint gated on that stale Redis value:

```python
redis_job = self.redis.load_job(job_id, user_id)
if redis_job.status != JobStatus.COMPLETED:   # stale: still RUN_EXPERTISE
    raise openreview.OpenReviewException(...)
```

So a genuinely-complete job was reported as still running. The sibling `get_expertise_results` never had this problem because it doesn't gate on status — it just reads the artifact from GCS.

## Fix

Drop the status check and read the metadata artifact directly:

```python
redis_job = self.redis.load_job(job_id, user_id)
return self.cloud.get_job_metadata(user_id, redis_job.cloud_id)
```

The artifact's presence in GCS is the source of truth for availability. We deliberately don't gate on job status because:

- **The client already gates.** Callers poll `get_expertise_status` (which resolves the *live* pipeline status) until `Completed`, then call `get_expertise_results` and `get_expertise_metadata`. Completion is guaranteed before metadata is requested.
- **Consistency.** `get_expertise_results` is called in the same `if Completed` block with no server-side gate; metadata now behaves identically.
- **No redundant Vertex round-trip.** Re-resolving the live status inside the endpoint would fire a second pipeline query right after the client's poll already returned `Completed`.
- **Robust to pipeline retention.** Vertex pipeline records can age out while GCS artifacts persist; a GCS read still serves those old jobs (a live status query would not).

If the artifact isn't there yet, `get_job_metadata` raises (404 for an unknown job, 403 for forbidden) through the route's existing error mapping.

## Changes

- [`service/expertise.py`](expertise/service/expertise.py) — `ExpertiseCloudService.get_expertise_metadata` no longer gates on the Redis-cached status; it reads `metadata.json` from GCS directly.

## Tests

- [`tests/test_expertise_cloud_service.py`](tests/test_expertise_cloud_service.py) — regression test in the journal flow: forces a stale `RUN_EXPERTISE` status into Redis while the pipeline mock reports `SUCCEEDED`/the metadata blob exists in GCS, and asserts `/expertise/metadata` still returns `200` with the metadata. Guards against re-introducing a stale-status gate.

## Migration notes

No API or response-shape changes. Existing callers that poll `/expertise/status` to `Completed` before requesting metadata are unaffected — they now succeed where the stale status previously caused a false "not available" error.
