### PR TITLE
Fix bullmq Worker asyncio loop mismatch

### DIFF
--- a/expertise/service/expertise.py
+++ b/expertise/service/expertise.py
@@ -84,25 +84,21 @@ class BaseExpertiseService:
         )
         self.start_queue_in_thread()
 
-        worker_settings = {
+        self.worker_settings = {
             'prefix': 'bullmq:expertise',
             'connection': {
                 "host": config['REDIS_ADDR'],
                 "port": config['REDIS_PORT'],
                 "db": config['REDIS_CONFIG_DB'],
             },
-            'autorun': worker_autorun
+            'autorun': False
         }
         if worker_concurrency is not None:
-            worker_settings['concurrency'] = worker_concurrency
+            self.worker_settings['concurrency'] = worker_concurrency
         if worker_lock_duration is not None:
-            worker_settings['lockDuration'] = worker_lock_duration
+            self.worker_settings['lockDuration'] = worker_lock_duration
 
-        self.worker = Worker(
-            'Expertise',
-            self.worker_process,
-            worker_settings
-        )
+        self.worker = None
         self.start_worker_in_thread()
 
         # Define required/optional fields if they are reused
@@ -139,19 +135,22 @@ class BaseExpertiseService:
         thread.start()
 
     def start_worker_in_thread(self):
-        def run_event_loop(loop):
+        def run_event_loop():
+            loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-            loop.run_forever()
+            self.worker = Worker(
+                'Expertise',
+                self.worker_process,
+                self.worker_settings
+            )
+            loop.run_until_complete(self.worker.run())
 
-        loop = asyncio.new_event_loop()
-        thread = threading.Thread(target=run_event_loop, args=(loop,), daemon=True)
+        thread = threading.Thread(target=run_event_loop, daemon=True)
         thread.start()
 
-        # Actually schedule the worker to run
-        asyncio.run_coroutine_threadsafe(self.worker.run(), loop)
-
     async def close(self):
-        await self.worker.close()
+        if self.worker is not None:
+            await self.worker.close()
         await self.queue.close()
 
     def worker_process(self, job, token):


### PR DESCRIPTION
- Instantiate Worker inside the daemon thread's event loop instead of on
the main gunicorn thread. BullMQ 2.11.0 creates internal asyncio.Futures
during Worker construction; when the Worker was constructed on one loop
but run() was scheduled on another, those Futures attached to the wrong
loop causing RuntimeError.
- Set autorun: False on Worker settings
- Move Worker instantiation into start_worker_in_thread()
- Use run_until_complete(worker.run()) instead of run_forever()
- Make close() defensive against self.worker = None